### PR TITLE
use gcd crate & provide a way to convert between `Instant` fractions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- `Instant::into` and `Instant::try_into` to convert between `Instant`s of different fractions (#13)
+
 ### Fixed
 
 ### Changed
+
+- Underlying method of calculating the GCD of fractions at compile time changed to `gcd` crate (#13)
 
 ## [v0.3.2]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+gcd = ">=2.1,<3.0"
 
 [dependencies.defmt]
 version = ">=0.2.0,<0.4"

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,4 +1,4 @@
-/// Needed due to not being allowed to call const-fn in `PartialEq` fo some reasion
+/// Needed due to not being allowed to call const-fn in `PartialEq` fo some reason
 /// get the error:
 ///
 /// ```console
@@ -20,7 +20,7 @@ impl<const L_NOM: u32, const L_DENOM: u32, const R_NOM: u32, const R_DENOM: u32>
 {
     /// Helper constants generated at compile time
     pub const DIVISOR: u64 =
-        gcd_binary_u64(L_DENOM as u64 * R_NOM as u64, R_DENOM as u64 * L_NOM as u64);
+        gcd::binary_u64(L_DENOM as u64 * R_NOM as u64, R_DENOM as u64 * L_NOM as u64);
 
     /// Helper constants generated at compile time
     pub const RD_TIMES_LN: u32 = ((R_DENOM as u64 * L_NOM as u64) / Self::DIVISOR) as u32;
@@ -30,40 +30,6 @@ impl<const L_NOM: u32, const L_DENOM: u32, const R_NOM: u32, const R_DENOM: u32>
 
     /// Helper constants generated at compile time
     pub const SAME_BASE: bool = Self::LD_TIMES_RN == Self::RD_TIMES_LN;
-}
-
-/// Greatest common denominator (GCD)
-pub const fn gcd_binary_u64(mut u: u64, mut v: u64) -> u64 {
-    if u == 0 {
-        return v;
-    }
-
-    if v == 0 {
-        return u;
-    }
-
-    let shift = (u | v).trailing_zeros();
-    u >>= shift;
-    v >>= shift;
-    u >>= u.trailing_zeros();
-
-    loop {
-        v >>= v.trailing_zeros();
-
-        if u > v {
-            let t = u;
-            u = v;
-            v = t;
-        }
-
-        v -= u; // here v >= u
-
-        if v == 0 {
-            break;
-        }
-    }
-
-    u << shift
 }
 
 #[allow(dead_code)]

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -205,11 +205,11 @@ macro_rules! impl_instant_for_integer {
 
             /// Infallibly convert to an [`Instant`] with a different fraction.
             ///
-            /// If the user provides incompatible fractions (i.e., to do the conversion we must
-            /// multiply by something other than one), we will fail to compile:
+            /// If the user provides incompatible fractions (i.e., to do the conversion we must multiply by something
+            /// other than one), we will fail to compile, even if the conversion wouldn't have overflown:
             /// ```compile_fail
-            #[doc = concat!("let i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(4_294_967_290);")]
-            /// let d = i.into::<7, 1_000>();
+            #[doc = concat!("let i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(42);")]
+            /// let d = i.into::<7, 2_000>();
             /// ```
             pub fn into<const O_NOM: u32, const O_DENOM: u32>(
                 self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -720,4 +720,18 @@ mod test {
         let diff: Instant<u64, 1, 10_000> = Instant::<u64, 1, 10_000>::from_ticks(10) - 1.millis();
         assert_eq!(diff, Instant::<u64, 1, 10_000>::from_ticks(0));
     }
+
+    #[test]
+    fn instant_try_into() {
+        let i = Instant::<u32, 1, 1_000>::from_ticks(40);
+        let d = i.try_into::<1, 250>().unwrap();
+        assert_eq!(d.ticks(), 10);
+    }
+
+    #[test]
+    fn instant_into() {
+        let i = Instant::<u32, 1, 1_000>::from_ticks(40);
+        let d = i.into::<1, 250>();
+        assert_eq!(d.ticks(), 10);
+    }
 }


### PR DESCRIPTION
remove existing const gcd implementation in favor of the GCD crate's implementation now that it provides it, and provide const `into` and `try_into` methods for converting between `Instant`s of different fractions