### PR TITLE
Implement *Assign ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Implement AddAssign and SubAssign for Instant and Duration, and
+  MulAssign and DivAssign for Duration.
+
 ### Fixed
 
 ### Changed

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -362,6 +362,16 @@ macro_rules! impl_duration_for_integer {
             }
         }
 
+        // Duration -= Duration
+        impl<const NOM: u32, const DENOM: u32> ops::SubAssign<Duration<$i, NOM, DENOM>>
+            for Duration<$i, NOM, DENOM>
+        {
+            #[inline]
+            fn sub_assign(&mut self, other: Self) {
+                *self = *self - other;
+            }
+        }
+
         // Duration + Duration = Duration (only same base until const_generics_defaults is
         // stabilized)
         impl<const NOM: u32, const DENOM: u32> ops::Add<Duration<$i, NOM, DENOM>>
@@ -376,6 +386,16 @@ macro_rules! impl_duration_for_integer {
                 } else {
                     panic!("Add failed!");
                 }
+            }
+        }
+
+        // Duration += Duration
+        impl<const NOM: u32, const DENOM: u32> ops::AddAssign<Duration<$i, NOM, DENOM>>
+            for Duration<$i, NOM, DENOM>
+        {
+            #[inline]
+            fn add_assign(&mut self, other: Self) {
+                *self = *self + other;
             }
         }
 
@@ -401,6 +421,16 @@ macro_rules! impl_duration_for_integer {
             }
         }
 
+        // Duration *= integer
+        impl<const NOM: u32, const DENOM: u32> ops::MulAssign<u32>
+            for Duration<$i, NOM, DENOM>
+        {
+            #[inline]
+            fn mul_assign(&mut self, other: u32) {
+                *self = *self * other;
+            }
+        }
+
         // Duration / integer = Duration
         impl<const NOM: u32, const DENOM: u32> ops::Div<u32> for Duration<$i, NOM, DENOM> {
             type Output = Duration<$i, NOM, DENOM>;
@@ -409,6 +439,16 @@ macro_rules! impl_duration_for_integer {
             fn div(mut self, other: u32) -> Self::Output {
                 self.ticks /= other as $i;
                 self
+            }
+        }
+
+        // Duration /= integer
+        impl<const NOM: u32, const DENOM: u32> ops::DivAssign<u32>
+            for Duration<$i, NOM, DENOM>
+        {
+            #[inline]
+            fn div_assign(&mut self, other: u32) {
+                *self = *self / other;
             }
         }
 
@@ -504,6 +544,16 @@ impl<const NOM: u32, const DENOM: u32> ops::Sub<Duration<u32, NOM, DENOM>>
     }
 }
 
+// Duration -= Duration (to make shorthands work, until const_generics_defaults is stabilized)
+impl<const NOM: u32, const DENOM: u32> ops::SubAssign<Duration<u32, NOM, DENOM>>
+    for Duration<u64, NOM, DENOM>
+{
+    #[inline]
+    fn sub_assign(&mut self, other: Duration<u32, NOM, DENOM>) {
+        *self = *self - other;
+    }
+}
+
 // Duration + Duration = Duration (to make shorthands work, until const_generics_defaults is
 // stabilized)
 impl<const NOM: u32, const DENOM: u32> ops::Add<Duration<u32, NOM, DENOM>>
@@ -520,6 +570,16 @@ impl<const NOM: u32, const DENOM: u32> ops::Add<Duration<u32, NOM, DENOM>>
         } else {
             panic!("Add failed!");
         }
+    }
+}
+
+// Duration += Duration (to make shorthands work, until const_generics_defaults is stabilized)
+impl<const NOM: u32, const DENOM: u32> ops::AddAssign<Duration<u32, NOM, DENOM>>
+    for Duration<u64, NOM, DENOM>
+{
+    #[inline]
+    fn add_assign(&mut self, other: Duration<u32, NOM, DENOM>) {
+        *self = *self + other;
     }
 }
 

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -236,6 +236,19 @@ macro_rules! impl_instant_for_integer {
             }
         }
 
+        // Instant -= Duration
+        // We have limited this to use same numerator and denominator in both left and right hand sides,
+        // this allows for the extension traits to work. For usage with different fraction, use
+        // `checked_sub_duration`.
+        impl<const NOM: u32, const DENOM: u32> ops::SubAssign<Duration<$i, NOM, DENOM>>
+            for Instant<$i, NOM, DENOM>
+        {
+            #[inline]
+            fn sub_assign(&mut self, other: Duration<$i, NOM, DENOM>) {
+                *self = *self - other;
+            }
+        }
+
         // Instant + Duration = Instant
         // We have limited this to use same numerator and denominator in both left and right hand sides,
         // this allows for the extension traits to work. For usage with different fraction, use
@@ -252,6 +265,19 @@ macro_rules! impl_instant_for_integer {
                 } else {
                     panic!("Add failed! Overflow");
                 }
+            }
+        }
+
+        // Instant += Duration
+        // We have limited this to use same numerator and denominator in both left and right hand sides,
+        // this allows for the extension traits to work. For usage with different fraction, use
+        // `checked_add_duration`.
+        impl<const NOM: u32, const DENOM: u32> ops::AddAssign<Duration<$i, NOM, DENOM>>
+            for Instant<$i, NOM, DENOM>
+        {
+            #[inline]
+            fn add_assign(&mut self, other: Duration<$i, NOM, DENOM>) {
+                *self = *self + other;
             }
         }
 
@@ -324,6 +350,19 @@ impl<const NOM: u32, const DENOM: u32> ops::Sub<Duration<u32, NOM, DENOM>>
     }
 }
 
+// Instant -= Duration
+// We have limited this to use same numerator and denominator in both left and right hand sides,
+// this allows for the extension traits to work. For usage with different fraction, use
+// `checked_sub_duration`.
+impl<const NOM: u32, const DENOM: u32> ops::SubAssign<Duration<u32, NOM, DENOM>>
+    for Instant<u64, NOM, DENOM>
+{
+    #[inline]
+    fn sub_assign(&mut self, other: Duration<u32, NOM, DENOM>) {
+        *self = *self - other;
+    }
+}
+
 // Instant + Duration = Instant
 // We have limited this to use same numerator and denominator in both left and right hand sides,
 // this allows for the extension traits to work. For usage with different fraction, use
@@ -342,6 +381,20 @@ impl<const NOM: u32, const DENOM: u32> ops::Add<Duration<u32, NOM, DENOM>>
         }
     }
 }
+
+// Instant += Duration
+// We have limited this to use same numerator and denominator in both left and right hand sides,
+// this allows for the extension traits to work. For usage with different fraction, use
+// `checked_add_duration`.
+impl<const NOM: u32, const DENOM: u32> ops::AddAssign<Duration<u32, NOM, DENOM>>
+    for Instant<u64, NOM, DENOM>
+{
+    #[inline]
+    fn add_assign(&mut self, other: Duration<u32, NOM, DENOM>) {
+        *self = *self + other;
+    }
+}
+
 // impl<const L_NOM: u32, const L_DENOM: u32, const R_NOM: u32, const R_DENOM: u32>
 //     ops::Add<Duration<u32, R_NOM, R_DENOM>> for Duration<u64, L_NOM, L_DENOM>
 // {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,8 +435,16 @@ mod test {
             Duration::<u32, 1, 1_000>::from_ticks(10) + Duration::<u32, 1, 1_000>::from_ticks(1);
         assert_eq!(sum, Duration::<u32, 1, 1_000>::from_ticks(11));
 
+        let mut sum = Duration::<u32, 1, 1_000>::from_ticks(10);
+        sum += Duration::<u32, 1, 1_000>::from_ticks(1);
+        assert_eq!(sum, Duration::<u32, 1, 1_000>::from_ticks(11));
+
         let diff: Duration<u32, 1, 1_000> =
             Duration::<u32, 1, 1_000>::from_ticks(10) - Duration::<u32, 1, 1_000>::from_ticks(1);
+        assert_eq!(diff, Duration::<u32, 1, 1_000>::from_ticks(9));
+
+        let mut diff = Duration::<u32, 1, 1_000>::from_ticks(10);
+        diff -= Duration::<u32, 1, 1_000>::from_ticks(1);
         assert_eq!(diff, Duration::<u32, 1, 1_000>::from_ticks(9));
 
         // Different base
@@ -444,17 +452,44 @@ mod test {
             + Duration::<u32, 1, 1_000>::from_ticks(1).convert();
         assert_eq!(sum, Duration::<u32, 1, 1_000>::from_ticks(2));
 
+        let mut sum = Duration::<u32, 1, 1_000>::from_ticks(1);
+        sum += Duration::<u32, 1, 10_000>::from_ticks(10).convert();
+        assert_eq!(sum, Duration::<u32, 1, 1_000>::from_ticks(2));
+
         let diff: Duration<u32, 1, 10_000> = Duration::<u32, 1, 10_000>::from_ticks(10)
             - Duration::<u32, 1, 1_000>::from_ticks(1).convert();
         assert_eq!(diff, Duration::<u32, 1, 10_000>::from_ticks(0));
+
+        let mut diff = Duration::<u32, 1, 1_000>::from_ticks(1);
+        diff -= Duration::<u32, 1, 10_000>::from_ticks(10).convert();
+        assert_eq!(diff, Duration::<u32, 1, 1_000>::from_ticks(0));
 
         // Short hand vs u32 (should not need `.into()`)
         let sum = Duration::<u32, 1, 10_000>::from_ticks(10) + 1.millis();
         assert_eq!(sum, Duration::<u32, 1, 10_000>::from_ticks(20));
 
+        let mut sum = Duration::<u32, 1, 10_000>::from_ticks(10);
+        sum += 1.millis();
+        assert_eq!(sum, Duration::<u32, 1, 10_000>::from_ticks(20));
+
         // Fixed in v0.3.2
         let d: Duration<u32, 1, 1_000> = Duration::<u32, 1, 32_768>::from_ticks(42949672).convert();
         assert_eq!(d.ticks(), 1_310_719);
+
+        // Division and multiplication by integers
+        let mul: Duration<u32, 1, 1_000> = Duration::<u32, 1, 1_000>::from_ticks(10) * 2;
+        assert_eq!(mul, Duration::<u32, 1, 1_000>::from_ticks(20));
+
+        let mut mul = Duration::<u32, 1, 1_000>::from_ticks(10);
+        mul *= 2;
+        assert_eq!(mul, Duration::<u32, 1, 1_000>::from_ticks(20));
+
+        let div: Duration<u32, 1, 1_000> = Duration::<u32, 1, 1_000>::from_ticks(10) / 2;
+        assert_eq!(div, Duration::<u32, 1, 1_000>::from_ticks(5));
+
+        let mut div = Duration::<u32, 1, 1_000>::from_ticks(10);
+        div /= 2;
+        assert_eq!(div, Duration::<u32, 1, 1_000>::from_ticks(5));
     }
 
     #[test]
@@ -466,8 +501,16 @@ mod test {
             Duration::<u64, 1, 1_000>::from_ticks(10) + Duration::<u64, 1, 1_000>::from_ticks(1);
         assert_eq!(sum, Duration::<u64, 1, 1_000>::from_ticks(11));
 
+        let mut sum = Duration::<u64, 1, 1_000>::from_ticks(10);
+        sum += Duration::<u64, 1, 1_000>::from_ticks(1);
+        assert_eq!(sum, Duration::<u64, 1, 1_000>::from_ticks(11));
+
         let diff: Duration<u64, 1, 1_000> =
             Duration::<u64, 1, 1_000>::from_ticks(10) - Duration::<u64, 1, 1_000>::from_ticks(1);
+        assert_eq!(diff, Duration::<u64, 1, 1_000>::from_ticks(9));
+
+        let mut diff = Duration::<u64, 1, 1_000>::from_ticks(10);
+        diff -= Duration::<u64, 1, 1_000>::from_ticks(1);
         assert_eq!(diff, Duration::<u64, 1, 1_000>::from_ticks(9));
 
         // Different base
@@ -475,13 +518,40 @@ mod test {
             + Duration::<u64, 1, 1_000>::from_ticks(1).convert();
         assert_eq!(sum, Duration::<u64, 1, 1_000>::from_ticks(2));
 
+        let mut sum = Duration::<u64, 1, 1_000>::from_ticks(1);
+        sum += Duration::<u64, 1, 10_000>::from_ticks(10).convert();
+        assert_eq!(sum, Duration::<u64, 1, 1_000>::from_ticks(2));
+
         let diff: Duration<u64, 1, 10_000> = Duration::<u64, 1, 10_000>::from_ticks(10)
             - Duration::<u64, 1, 1_000>::from_ticks(1).convert();
+        assert_eq!(diff, Duration::<u64, 1, 1_000>::from_ticks(0));
+
+        let mut diff = Duration::<u64, 1, 1_000>::from_ticks(1);
+        diff -= Duration::<u64, 1, 10_000>::from_ticks(10).convert();
         assert_eq!(diff, Duration::<u64, 1, 1_000>::from_ticks(0));
 
         // Short hand vs u64 (should not need `.into()`)
         let sum = Duration::<u64, 1, 10_000>::from_ticks(10) + 1.millis();
         assert_eq!(sum, Duration::<u64, 1, 10_000>::from_ticks(20));
+
+        let mut sum = Duration::<u64, 1, 10_000>::from_ticks(10);
+        sum += 1.millis();
+        assert_eq!(sum, Duration::<u64, 1, 10_000>::from_ticks(20));
+
+        // Division and multiplication by integers
+        let mul: Duration<u64, 1, 1_000> = Duration::<u64, 1, 1_000>::from_ticks(10) * 2;
+        assert_eq!(mul, Duration::<u64, 1, 1_000>::from_ticks(20));
+
+        let mut mul = Duration::<u64, 1, 1_000>::from_ticks(10);
+        mul *= 2;
+        assert_eq!(mul, Duration::<u64, 1, 1_000>::from_ticks(20));
+
+        let div: Duration<u64, 1, 1_000> = Duration::<u64, 1, 1_000>::from_ticks(10) / 2;
+        assert_eq!(div, Duration::<u64, 1, 1_000>::from_ticks(5));
+
+        let mut div = Duration::<u64, 1, 1_000>::from_ticks(10);
+        div /= 2;
+        assert_eq!(div, Duration::<u64, 1, 1_000>::from_ticks(5));
     }
 
     #[test]
@@ -491,8 +561,16 @@ mod test {
             Duration::<u64, 1, 1_000>::from_ticks(10) + Duration::<u32, 1, 1_000>::from_ticks(1);
         assert_eq!(sum, Duration::<u64, 1, 1_000>::from_ticks(11));
 
+        let mut sum = Duration::<u64, 1, 1_000>::from_ticks(10);
+        sum += Duration::<u32, 1, 1_000>::from_ticks(1);
+        assert_eq!(sum, Duration::<u64, 1, 1_000>::from_ticks(11));
+
         let diff: Duration<u64, 1, 1_000> =
             Duration::<u64, 1, 1_000>::from_ticks(10) - Duration::<u32, 1, 1_000>::from_ticks(1);
+        assert_eq!(diff, Duration::<u64, 1, 1_000>::from_ticks(9));
+
+        let mut diff = Duration::<u64, 1, 1_000>::from_ticks(10);
+        diff -= Duration::<u32, 1, 1_000>::from_ticks(1);
         assert_eq!(diff, Duration::<u64, 1, 1_000>::from_ticks(9));
 
         // Different base
@@ -500,8 +578,16 @@ mod test {
             + Duration::<u32, 1, 1_000>::from_ticks(1).convert();
         assert_eq!(sum, Duration::<u64, 1, 1_000>::from_ticks(2));
 
+        let mut sum = Duration::<u64, 1, 1_000>::from_ticks(1);
+        sum += Duration::<u32, 1, 10_000>::from_ticks(10).convert();
+        assert_eq!(sum, Duration::<u64, 1, 1_000>::from_ticks(2));
+
         let diff: Duration<u64, 1, 10_000> = Duration::<u64, 1, 10_000>::from_ticks(10)
             - Duration::<u32, 1, 1_000>::from_ticks(1).convert();
+        assert_eq!(diff, Duration::<u64, 1, 1_000>::from_ticks(0));
+
+        let mut diff = Duration::<u64, 1, 1_000>::from_ticks(1);
+        diff -= Duration::<u32, 1, 10_000>::from_ticks(10).convert();
         assert_eq!(diff, Duration::<u64, 1, 1_000>::from_ticks(0));
     }
 
@@ -658,22 +744,38 @@ mod test {
             Instant::<u32, 1, 1_000>::from_ticks(10) - Instant::<u32, 1, 1_000>::from_ticks(1);
         assert_eq!(diff, Duration::<u32, 1, 1_000>::from_ticks(9));
 
-        // Instant + Duration, Same base
+        // Instant +- Duration, Same base
         let sum: Instant<u32, 1, 1_000> =
             Instant::<u32, 1, 1_000>::from_ticks(10) + Duration::<u32, 1, 1_000>::from_ticks(1);
+        assert_eq!(sum, Instant::<u32, 1, 1_000>::from_ticks(11));
+
+        let mut sum = Instant::<u32, 1, 1_000>::from_ticks(10);
+        sum += Duration::<u32, 1, 1_000>::from_ticks(1);
         assert_eq!(sum, Instant::<u32, 1, 1_000>::from_ticks(11));
 
         let diff: Instant<u32, 1, 1_000> =
             Instant::<u32, 1, 1_000>::from_ticks(10) - Duration::<u32, 1, 1_000>::from_ticks(1);
         assert_eq!(diff, Instant::<u32, 1, 1_000>::from_ticks(9));
 
-        // Instant - Duration, Different base
+        let mut diff = Instant::<u32, 1, 1_000>::from_ticks(10);
+        diff -= Duration::<u32, 1, 1_000>::from_ticks(1);
+        assert_eq!(diff, Instant::<u32, 1, 1_000>::from_ticks(9));
+
+        // Instant +- Duration, Different base
         let sum: Instant<u32, 1, 10_000> = Instant::<u32, 1, 10_000>::from_ticks(10)
             + Duration::<u32, 1, 1_000>::from_ticks(1).convert();
         assert_eq!(sum, Instant::<u32, 1, 10_000>::from_ticks(20));
 
+        let mut sum = Instant::<u32, 1, 10_000>::from_ticks(10);
+        sum += Duration::<u32, 1, 1_000>::from_ticks(1).convert();
+        assert_eq!(sum, Instant::<u32, 1, 10_000>::from_ticks(20));
+
         let diff: Instant<u32, 1, 10_000> = Instant::<u32, 1, 10_000>::from_ticks(10)
             - Duration::<u32, 1, 1_000>::from_ticks(1).convert();
+        assert_eq!(diff, Instant::<u32, 1, 10_000>::from_ticks(0));
+
+        let mut diff = Instant::<u32, 1, 10_000>::from_ticks(10);
+        diff -= Duration::<u32, 1, 1_000>::from_ticks(1).convert();
         assert_eq!(diff, Instant::<u32, 1, 10_000>::from_ticks(0));
 
         // Instant + Extension trait
@@ -694,22 +796,38 @@ mod test {
             Instant::<u64, 1, 1_000>::from_ticks(10) - Instant::<u64, 1, 1_000>::from_ticks(1);
         assert_eq!(diff, Duration::<u64, 1, 1_000>::from_ticks(9));
 
-        // Instant + Duration, Same base
+        // Instant +- Duration, Same base
         let sum: Instant<u64, 1, 1_000> =
             Instant::<u64, 1, 1_000>::from_ticks(10) + Duration::<u64, 1, 1_000>::from_ticks(1);
+        assert_eq!(sum, Instant::<u64, 1, 1_000>::from_ticks(11));
+
+        let mut sum = Instant::<u64, 1, 1_000>::from_ticks(10);
+        sum += Duration::<u64, 1, 1_000>::from_ticks(1);
         assert_eq!(sum, Instant::<u64, 1, 1_000>::from_ticks(11));
 
         let diff: Instant<u64, 1, 1_000> =
             Instant::<u64, 1, 1_000>::from_ticks(10) - Duration::<u64, 1, 1_000>::from_ticks(1);
         assert_eq!(diff, Instant::<u64, 1, 1_000>::from_ticks(9));
 
-        // Instant - Duration, Different base
+        let mut diff = Instant::<u64, 1, 1_000>::from_ticks(10);
+        diff -= Duration::<u64, 1, 1_000>::from_ticks(1);
+        assert_eq!(diff, Instant::<u64, 1, 1_000>::from_ticks(9));
+
+        // Instant +- Duration, Different base
         let sum: Instant<u64, 1, 10_000> = Instant::<u64, 1, 10_000>::from_ticks(10)
             + Duration::<u64, 1, 1_000>::from_ticks(1).convert();
         assert_eq!(sum, Instant::<u64, 1, 10_000>::from_ticks(20));
 
+        let mut sum = Instant::<u64, 1, 10_000>::from_ticks(10);
+        sum += Duration::<u64, 1, 1_000>::from_ticks(1).convert();
+        assert_eq!(sum, Instant::<u64, 1, 10_000>::from_ticks(20));
+
         let diff: Instant<u64, 1, 10_000> = Instant::<u64, 1, 10_000>::from_ticks(10)
             - Duration::<u64, 1, 1_000>::from_ticks(1).convert();
+        assert_eq!(diff, Instant::<u64, 1, 10_000>::from_ticks(0));
+
+        let mut diff = Instant::<u64, 1, 10_000>::from_ticks(10);
+        diff -= Duration::<u64, 1, 1_000>::from_ticks(1).convert();
         assert_eq!(diff, Instant::<u64, 1, 10_000>::from_ticks(0));
 
         // Instant + Extension trait
@@ -718,6 +836,43 @@ mod test {
 
         // Instant - Extension trait
         let diff: Instant<u64, 1, 10_000> = Instant::<u64, 1, 10_000>::from_ticks(10) - 1.millis();
+        assert_eq!(diff, Instant::<u64, 1, 10_000>::from_ticks(0));
+    }
+
+    #[test]
+    fn instant_duration_math_u64_u32() {
+        // Instant +- Duration, Same base
+        let sum: Instant<u64, 1, 1_000> =
+            Instant::<u64, 1, 1_000>::from_ticks(10) + Duration::<u32, 1, 1_000>::from_ticks(1);
+        assert_eq!(sum, Instant::<u64, 1, 1_000>::from_ticks(11));
+
+        let mut sum = Instant::<u64, 1, 1_000>::from_ticks(10);
+        sum += Duration::<u32, 1, 1_000>::from_ticks(1);
+        assert_eq!(sum, Instant::<u64, 1, 1_000>::from_ticks(11));
+
+        let diff: Instant<u64, 1, 1_000> =
+            Instant::<u64, 1, 1_000>::from_ticks(10) - Duration::<u32, 1, 1_000>::from_ticks(1);
+        assert_eq!(diff, Instant::<u64, 1, 1_000>::from_ticks(9));
+
+        let mut diff = Instant::<u64, 1, 1_000>::from_ticks(10);
+        diff -= Duration::<u32, 1, 1_000>::from_ticks(1);
+        assert_eq!(diff, Instant::<u64, 1, 1_000>::from_ticks(9));
+
+        // Instant +- Duration, Different base
+        let sum: Instant<u64, 1, 10_000> = Instant::<u64, 1, 10_000>::from_ticks(10)
+            + Duration::<u32, 1, 1_000>::from_ticks(1).convert();
+        assert_eq!(sum, Instant::<u64, 1, 10_000>::from_ticks(20));
+
+        let mut sum = Instant::<u64, 1, 10_000>::from_ticks(10);
+        sum += Duration::<u32, 1, 1_000>::from_ticks(1).convert();
+        assert_eq!(sum, Instant::<u64, 1, 10_000>::from_ticks(20));
+
+        let diff: Instant<u64, 1, 10_000> = Instant::<u64, 1, 10_000>::from_ticks(10)
+            - Duration::<u32, 1, 1_000>::from_ticks(1).convert();
+        assert_eq!(diff, Instant::<u64, 1, 10_000>::from_ticks(0));
+
+        let mut diff = Instant::<u64, 1, 10_000>::from_ticks(10);
+        diff -= Duration::<u32, 1, 1_000>::from_ticks(1).convert();
         assert_eq!(diff, Instant::<u64, 1, 10_000>::from_ticks(0));
     }
 }


### PR DESCRIPTION
Implements +=, -=, *=, and /= where appropriate, by using the existing +, -, *, and / operators.

This allows for example:

```rust
let mut t = MillisDurationU64::millis(100);
t += MillisDurationU64::millis(900);
```

instead of what's currently required:

```rust
let mut t = MillisDurationU64::millis(100);
t = t + MillisDurationU64::millis(900);
```

Sorry if this has been considered before, I couldn't find any previous discussions. I tried to add it wherever it makes sense alongside an existing operator implementation.