### PR TITLE
Add nanosecond units alongside the others

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Add `nanos()` methods and `NanosDuration` aliases alongside other units.
+
 ### Fixed
 
 ### Changed

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -3,6 +3,15 @@
 use crate::duration::Duration;
 use crate::instant::Instant;
 
+/// Alias for nanosecond duration
+pub type NanosDuration<T> = Duration<T, 1, 1_000_000_000>;
+
+/// Alias for nanosecond duration (`u32` backing storage)
+pub type NanosDurationU32 = Duration<u32, 1, 1_000_000_000>;
+
+/// Alias for nanosecond duration (`u64` backing storage)
+pub type NanosDurationU64 = Duration<u64, 1, 1_000_000_000>;
+
 /// Alias for microsecond duration
 pub type MicrosDuration<T> = Duration<T, 1, 1_000_000>;
 

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -272,6 +272,15 @@ macro_rules! impl_duration_for_integer {
                 }
             }
 
+            /// Shorthand for creating a duration which represents nanoseconds.
+            #[inline]
+            pub const fn nanos(val: $i) -> Duration<$i, NOM, DENOM> {
+                Duration::<$i, NOM, DENOM>::from_ticks(
+                    (Helpers::<1, 1_000_000_000, NOM, DENOM>::RD_TIMES_LN as $i * val)
+                        / Helpers::<1, 1_000_000_000, NOM, DENOM>::LD_TIMES_RN as $i,
+                )
+            }
+
             /// Shorthand for creating a duration which represents microseconds.
             #[inline]
             pub const fn micros(val: $i) -> Duration<$i, NOM, DENOM> {
@@ -565,6 +574,9 @@ impl<const L_NOM: u32, const L_DENOM: u32, const R_NOM: u32, const R_DENOM: u32>
 
 /// Extension trait for simple short-hands for u32 Durations
 pub trait ExtU32 {
+    /// Shorthand for creating a duration which represents nanoseconds.
+    fn nanos<const NOM: u32, const DENOM: u32>(self) -> Duration<u32, NOM, DENOM>;
+
     /// Shorthand for creating a duration which represents microseconds.
     fn micros<const NOM: u32, const DENOM: u32>(self) -> Duration<u32, NOM, DENOM>;
 
@@ -582,6 +594,11 @@ pub trait ExtU32 {
 }
 
 impl ExtU32 for u32 {
+    #[inline]
+    fn nanos<const NOM: u32, const DENOM: u32>(self) -> Duration<u32, NOM, DENOM> {
+        Duration::<u32, NOM, DENOM>::nanos(self)
+    }
+
     #[inline]
     fn micros<const NOM: u32, const DENOM: u32>(self) -> Duration<u32, NOM, DENOM> {
         Duration::<u32, NOM, DENOM>::micros(self)
@@ -610,6 +627,9 @@ impl ExtU32 for u32 {
 
 /// Extension trait for simple short-hands for u64 Durations
 pub trait ExtU64 {
+    /// Shorthand for creating a duration which represents nanoseconds.
+    fn nanos<const NOM: u32, const DENOM: u32>(self) -> Duration<u64, NOM, DENOM>;
+
     /// Shorthand for creating a duration which represents microseconds.
     fn micros<const NOM: u32, const DENOM: u32>(self) -> Duration<u64, NOM, DENOM>;
 
@@ -627,6 +647,11 @@ pub trait ExtU64 {
 }
 
 impl ExtU64 for u64 {
+    #[inline]
+    fn nanos<const NOM: u32, const DENOM: u32>(self) -> Duration<u64, NOM, DENOM> {
+        Duration::<u64, NOM, DENOM>::nanos(self)
+    }
+
     #[inline]
     fn micros<const NOM: u32, const DENOM: u32>(self) -> Duration<u64, NOM, DENOM> {
         Duration::<u64, NOM, DENOM>::micros(self)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,6 +509,9 @@ mod test {
     fn duration_shorthands_u32() {
         use crate::ExtU32;
 
+        let d: Duration<u32, 1, 10_000> = 100_000_000.nanos();
+        assert_eq!(d.ticks(), 1_000);
+
         let d: Duration<u32, 1, 10_000> = 100_000.micros();
         assert_eq!(d.ticks(), 1_000);
 
@@ -528,6 +531,9 @@ mod test {
     #[test]
     fn duration_shorthands_u64() {
         use crate::ExtU64;
+
+        let d: Duration<u64, 1, 10_000> = 100_000_000.nanos();
+        assert_eq!(d.ticks(), 1_000);
 
         let d: Duration<u64, 1, 10_000> = 100_000.micros();
         assert_eq!(d.ticks(), 1_000);


### PR DESCRIPTION
Since fugit already supports rendering nanosecond timebases, perhaps we could include nanoseconds alongside microseconds etc. Nanoseconds are used for [PTP](https://en.wikipedia.org/wiki/Precision_Time_Protocol) times so it would make working with them more convenient.

By the way, I added `.gitattributes` to make merge conflicts on CHANGELOG less likely; `union` means it will try and combine lines from both commits if possible which should do the right thing on a changelog. Happy to take this out if you want, of course!