### PR TITLE
Add Duration::to_nanos, to_micros, to_millis, to_secs, to_minutes, to_hours methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `nanos()` methods and `NanosDuration` aliases alongside other units.
 - Implement AddAssign and SubAssign for Instant and Duration, and
   MulAssign and DivAssign for Duration.
+- Add `to_nanos()`, `to_micros()`, `to_millis()`, `to_secs()`, `to_minutes()`,
+  and `to_hours()` methods to `Duration<u32, NOM, DENOM>` and
+  `Duration<u64, NOM, DENOM>` types to easily convert to integer time units.
 
 ### Fixed
 

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -272,6 +272,48 @@ macro_rules! impl_duration_for_integer {
                 }
             }
 
+            /// Convert the Duration to an integer number of nanoseconds.
+            #[inline]
+            pub const fn to_nanos(&self) -> $i {
+                (Helpers::<1, 1_000_000_000, NOM, DENOM>::LD_TIMES_RN as $i * self.ticks)
+                    / Helpers::<1, 1_000_000_000, NOM, DENOM>::RD_TIMES_LN as $i
+            }
+
+            /// Convert the Duration to an integer number of microseconds.
+            #[inline]
+            pub const fn to_micros(&self) -> $i {
+                (Helpers::<1, 1_000_000, NOM, DENOM>::LD_TIMES_RN as $i * self.ticks)
+                    / Helpers::<1, 1_000_000, NOM, DENOM>::RD_TIMES_LN as $i
+            }
+
+            /// Convert the Duration to an integer number of milliseconds.
+            #[inline]
+            pub const fn to_millis(&self) -> $i {
+                (Helpers::<1, 1_000, NOM, DENOM>::LD_TIMES_RN as $i * self.ticks)
+                    / Helpers::<1, 1_000, NOM, DENOM>::RD_TIMES_LN as $i
+            }
+
+            /// Convert the Duration to an integer number of seconds.
+            #[inline]
+            pub const fn to_secs(&self) -> $i {
+                (Helpers::<1, 1, NOM, DENOM>::LD_TIMES_RN as $i * self.ticks)
+                    / Helpers::<1, 1, NOM, DENOM>::RD_TIMES_LN as $i
+            }
+
+            /// Convert the Duration to an integer number of minutes.
+            #[inline]
+            pub const fn to_minutes(&self) -> $i {
+                (Helpers::<60, 1, NOM, DENOM>::LD_TIMES_RN as $i * self.ticks)
+                    / Helpers::<60, 1, NOM, DENOM>::RD_TIMES_LN as $i
+            }
+
+            /// Convert the Duration to an integer number of hours.
+            #[inline]
+            pub const fn to_hours(&self) -> $i {
+                (Helpers::<3_600, 1, NOM, DENOM>::LD_TIMES_RN as $i * self.ticks)
+                    / Helpers::<3_600, 1, NOM, DENOM>::RD_TIMES_LN as $i
+            }
+
             /// Shorthand for creating a duration which represents nanoseconds.
             #[inline]
             pub const fn nanos(val: $i) -> Duration<$i, NOM, DENOM> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,6 +612,32 @@ mod test {
 
         let d: Duration<u32, 1, 10_000> = 1.hours();
         assert_eq!(d.ticks(), 36_000_000);
+
+        let d = Duration::<u32, 1, 1>::from_ticks(2);
+        assert_eq!(d.to_secs(), 2);
+        assert_eq!(d.to_nanos(), 2_000_000_000);
+
+        let d = Duration::<u32, 1, 1_000_000_000>::from_ticks(2_000_000_000);
+        assert_eq!(d.to_secs(), 2);
+        assert_eq!(d.to_nanos(), 2_000_000_000);
+
+        let d = Duration::<u32, 1, 10_000>::from_ticks(100);
+        assert_eq!(d.to_nanos(), 10_000_000);
+
+        let d = Duration::<u32, 1, 10_000>::from_ticks(100);
+        assert_eq!(d.to_micros(), 10_000);
+
+        let d = Duration::<u32, 1, 10_000>::from_ticks(100);
+        assert_eq!(d.to_millis(), 10);
+
+        let d = Duration::<u32, 1, 10_000>::from_ticks(100_000);
+        assert_eq!(d.to_secs(), 10);
+
+        let d = Duration::<u32, 1, 10_000>::from_ticks(1_800_000);
+        assert_eq!(d.to_minutes(), 3);
+
+        let d = Duration::<u32, 1, 10_000>::from_ticks(180_000_000);
+        assert_eq!(d.to_hours(), 5);
     }
 
     #[test]
@@ -635,6 +661,32 @@ mod test {
 
         let d: Duration<u64, 1, 10_000> = 1.hours();
         assert_eq!(d.ticks(), 36_000_000);
+
+        let d = Duration::<u32, 1, 1>::from_ticks(2);
+        assert_eq!(d.to_secs(), 2);
+        assert_eq!(d.to_nanos(), 2_000_000_000);
+
+        let d = Duration::<u32, 1, 1_000_000_000>::from_ticks(2_000_000_000);
+        assert_eq!(d.to_secs(), 2);
+        assert_eq!(d.to_nanos(), 2_000_000_000);
+
+        let d = Duration::<u64, 1, 10_000>::from_ticks(100);
+        assert_eq!(d.to_nanos(), 10_000_000);
+
+        let d = Duration::<u64, 1, 10_000>::from_ticks(100);
+        assert_eq!(d.to_micros(), 10_000);
+
+        let d = Duration::<u64, 1, 10_000>::from_ticks(100);
+        assert_eq!(d.to_millis(), 10);
+
+        let d = Duration::<u64, 1, 10_000>::from_ticks(100_000);
+        assert_eq!(d.to_secs(), 10);
+
+        let d = Duration::<u64, 1, 10_000>::from_ticks(1_800_000);
+        assert_eq!(d.to_minutes(), 3);
+
+        let d = Duration::<u64, 1, 10_000>::from_ticks(180_000_000);
+        assert_eq!(d.to_hours(), 5);
     }
 
     #[test]


### PR DESCRIPTION
I was worried this might lead to overflows when doing something like
```rust
Duration::<u32, 1, 1_000_000_000>::from_ticks(1_000_000_000).to_nanos()
```
because it's working out
```rust
(1_000_000_000u32 * 1_000_000_000u32)/1_000_000_000u32
```
but in practice it seems to do the right thing (and I cover this case with tests).

In any event the maths is exactly the inverse of the existing `micros()` etc methods, so I guess it should work or fail in the same ways.