### PR TITLE
Mention wrap-around behavior of const_cmp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Updated documentation of const_cmp
+
 ## [v0.3.6] 
 
 ### Fixed


### PR DESCRIPTION
This relates to #36.

While the correct fix for #36 (if any) seems to be controversial, let's first document how the functions work in their current form.