### PR TITLE
Fix boundary bugs in Duration and Rate conversions and release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.4.0] - 2026-05-06
+
 ### Added
 
 - `Duration::ZERO` and `Duration::MAX` constants
@@ -25,6 +27,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Issue #50: Rate conversions now use half-up rounding instead of truncating for better accuracy
 - Issue #53: Overflow detection in shorthand conversions (e.g., `NanosDurationU32.minutes()`)
 - Added `#[track_caller]` to all panicking functions for better error locations
+- `Duration::const_try_from`/`const_try_into`/`convert` (and the same on `Rate`) no longer overflow `u64` silently when ticks are close to `u64::MAX`. The rounding step `(lh + d/2) / d` was replaced with an overflow-free divmod-based form that produces the same rounded result without ever wrapping.
+- `Duration::Hz`/`kHz`/`MHz`, `Rate::Hz`/`kHz`/`MHz`, `Rate::to_Hz`/`to_kHz`/`to_MHz`, `Duration::try_from_rate`, and `Rate::try_from_duration` now produce a compile-time error when the conversion constants don't fit the storage type, instead of silently truncating `u64` constants on a `u32` cast.
+- The `Duration` shorthand methods (`as_*`, `from_*`, `from_*_at_least`) and the `Rate::Hz`/`kHz`/`MHz`/`to_Hz`/`to_kHz`/`to_MHz` family now panic on multiplication overflow instead of silently wrapping in release builds. All gained `#[track_caller]` so the panic points at the user's call site.
 
 ### Changed
 
@@ -137,7 +142,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Now supports a `defmt` version span (0.2 and 0.3 is supported)
 
-[Unreleased]: https://github.com/korken89/fugit/compare/v0.3.9...HEAD
+[Unreleased]: https://github.com/korken89/fugit/compare/v0.4.0...HEAD
+[v0.4.0]: https://github.com/korken89/fugit/compare/v0.3.9...v0.4.0
 [v0.3.9]: https://github.com/korken89/fugit/compare/v0.3.8...v0.3.9
 [v0.3.8]: https://github.com/korken89/fugit/compare/v0.3.7...v0.3.8
 [v0.3.7]: https://github.com/korken89/fugit/compare/v0.3.6...v0.3.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,14 +19,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support for picosecond-level precision (enabled by u64 const generics)
 - `picos()` shorthand method to `ExtU32`, `ExtU64`, `ExtU32Ceil`, and `ExtU64Ceil` traits
 - `Duration::from_picos`, `as_picos`, `from_picos_at_least` methods
+- `PicosDuration<T>`, `PicosDurationU32`, `PicosDurationU64` aliases
+- `Gigahertz<T>`, `GigahertzU32`, `GigahertzU64` aliases (the `defmt`/`Display` impls already formatted this base as `GHz`)
 - `core::ops::Rem` and `core::ops::RemAssign` trait implementations for `Rate` and `Duration` (fixes #41)
+- `core::ops::SubAssign` for `Rate` (was missing; asymmetric with `Add`/`AddAssign`/`Sub`)
 - Conversion to/from `core::time::Duration`
 
 ### Fixed
 
 - Issue #50: Rate conversions now use half-up rounding instead of truncating for better accuracy
 - Issue #53: Overflow detection in shorthand conversions (e.g., `NanosDurationU32.minutes()`)
-- Added `#[track_caller]` to all panicking functions for better error locations
+- Added `#[track_caller]` to all panicking functions and operator impls (including `*Assign` wrappers, `Mul`/`Div`/`Rem` on integers, and the cross-type `u32`<->`u64` ops) so panic locations point at the user's call site.
+- Documentation clarifications across `Instant::checked_*_duration`, `Instant::checked_duration_since`, `Duration::checked_*` / `Rate::checked_*`, the `try_from_*`/`try_to_*` conversions, and the `const_partial_cmp`/`const_eq` methods. Several methods previously claimed to "check for overflow" or "check for divide-by-zero" while the actual contract was different (e.g. wrapping ticks, returning `None` on cross-base conversion overflow).
 - `Duration::const_try_from`/`const_try_into`/`convert` (and the same on `Rate`) no longer overflow `u64` silently when ticks are close to `u64::MAX`. The rounding step `(lh + d/2) / d` was replaced with an overflow-free divmod-based form that produces the same rounded result without ever wrapping.
 - `Duration::Hz`/`kHz`/`MHz`, `Rate::Hz`/`kHz`/`MHz`, `Rate::to_Hz`/`to_kHz`/`to_MHz`, `Duration::try_from_rate`, and `Rate::try_from_duration` now produce a compile-time error when the conversion constants don't fit the storage type, instead of silently truncating `u64` constants on a `u32` cast.
 - The `Duration` shorthand methods (`as_*`, `from_*`, `from_*_at_least`) and the `Rate::Hz`/`kHz`/`MHz`/`to_Hz`/`to_kHz`/`to_MHz` family now panic on multiplication overflow instead of silently wrapping in release builds. All gained `#[track_caller]` so the panic points at the user's call site.

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -4,6 +4,15 @@ use crate::Duration;
 use crate::Instant;
 use crate::Rate;
 
+/// Alias for picosecond duration
+pub type PicosDuration<T> = Duration<T, 1, 1_000_000_000_000>;
+
+/// Alias for picosecond duration (`u32` backing storage)
+pub type PicosDurationU32 = Duration<u32, 1, 1_000_000_000_000>;
+
+/// Alias for picosecond duration (`u64` backing storage)
+pub type PicosDurationU64 = Duration<u64, 1, 1_000_000_000_000>;
+
 /// Alias for nanosecond duration
 pub type NanosDuration<T> = Duration<T, 1, 1_000_000_000>;
 
@@ -106,6 +115,15 @@ pub type MegahertzU32 = Rate<u32, 1_000_000, 1>;
 
 /// Alias for megahertz rate (`u64` backing storage)
 pub type MegahertzU64 = Rate<u64, 1_000_000, 1>;
+
+/// Alias for gigahertz rate
+pub type Gigahertz<T> = Rate<T, 1_000_000_000, 1>;
+
+/// Alias for gigahertz rate (`u32` backing storage)
+pub type GigahertzU32 = Rate<u32, 1_000_000_000, 1>;
+
+/// Alias for gigahertz rate (`u64` backing storage)
+pub type GigahertzU64 = Rate<u64, 1_000_000_000, 1>;
 
 /// Alias for rate that come from timers with a specific frequency
 pub type TimerRate<T, const FREQ_HZ: u64> = Rate<T, FREQ_HZ, 1>;

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -1,4 +1,4 @@
-use crate::helpers::Helpers;
+use crate::helpers::{div_round_nearest_u64, Helpers};
 use crate::NanosDurationU64;
 use crate::Rate;
 use crate::SecsDurationU64;
@@ -20,14 +20,26 @@ pub struct Duration<T, const NOM: u64, const DENOM: u64> {
     pub(crate) ticks: T,
 }
 
+// Unwrap a const-time `Option` or panic with the given static message. Lets the
+// shorthand methods turn `checked_mul` failures into a clear panic at the user's
+// call site instead of silently wrapping in release builds.
+macro_rules! const_checked {
+    ($e:expr, $msg:expr) => {
+        match $e {
+            Some(v) => v,
+            None => panic!("{}", $msg),
+        }
+    };
+}
+
 macro_rules! shorthand {
     ($i:ty, $nom:literal, $denum:literal, $from_unit:ident, $as_unit:ident, $from_unital:ident, $unitstr:literal) => {
         #[doc = concat!("Convert the Duration to an integer number of ", $unitstr, ".")]
         #[doc = ""]
-        #[doc = concat!("**Warning**: This function will cause a compilation error if the conversion constants don't fit in `", stringify!($i), "`.")]
+        #[doc = concat!("**Compile-time error** if the conversion constants don't fit in `", stringify!($i), "`. **Panics** if the multiplication overflows `", stringify!($i), "`.")]
         #[inline]
+        #[track_caller]
         pub const fn $as_unit(&self) -> $i {
-            // Compile-time/runtime check - will fail if constants don't fit in target type
             const {
                 assert!(
                     Helpers::<$nom, $denum, NOM, DENOM>::RD_TIMES_LN <= <$i>::MAX as u64,
@@ -39,16 +51,19 @@ macro_rules! shorthand {
                 );
             }
 
-            (Helpers::<$nom, $denum, NOM, DENOM>::LD_TIMES_RN as $i * self.ticks)
-                / Helpers::<$nom, $denum, NOM, DENOM>::RD_TIMES_LN as $i
+            let prod = const_checked!(
+                (Helpers::<$nom, $denum, NOM, DENOM>::LD_TIMES_RN as $i).checked_mul(self.ticks),
+                concat!("Duration::", stringify!($as_unit), ": multiplication overflowed storage type")
+            );
+            prod / Helpers::<$nom, $denum, NOM, DENOM>::RD_TIMES_LN as $i
         }
 
         #[doc = concat!("Create a duration from a number of ", $unitstr, ".")]
         #[doc = ""]
-        #[doc = concat!("**Warning**: This function will cause a compilation error if the conversion constants don't fit in `", stringify!($i), "`.")]
+        #[doc = concat!("**Compile-time error** if the conversion constants don't fit in `", stringify!($i), "`. **Panics** if the multiplication overflows `", stringify!($i), "`.")]
         #[inline]
+        #[track_caller]
         pub const fn $from_unit(val: $i) -> Self {
-            // Compile-time/runtime check - will fail if constants don't fit in target type
             const {
                 assert!(
                     Helpers::<$nom, $denum, NOM, DENOM>::RD_TIMES_LN <= <$i>::MAX as u64,
@@ -60,18 +75,19 @@ macro_rules! shorthand {
                 );
             }
 
-            Self::from_ticks(
-                (Helpers::<$nom, $denum, NOM, DENOM>::RD_TIMES_LN as $i * val)
-                    / Helpers::<$nom, $denum, NOM, DENOM>::LD_TIMES_RN as $i
-            )
+            let prod = const_checked!(
+                (Helpers::<$nom, $denum, NOM, DENOM>::RD_TIMES_LN as $i).checked_mul(val),
+                concat!("Duration::", stringify!($from_unit), ": multiplication overflowed storage type")
+            );
+            Self::from_ticks(prod / Helpers::<$nom, $denum, NOM, DENOM>::LD_TIMES_RN as $i)
         }
 
         #[doc = concat!("Create a duration from a number of ", $unitstr, " (ceil rounded).")]
         #[doc = ""]
-        #[doc = concat!("**Warning**: This function will cause a compilation error if the conversion constants don't fit in `", stringify!($i), "`.")]
+        #[doc = concat!("**Compile-time error** if the conversion constants don't fit in `", stringify!($i), "`. **Panics** if the multiplication overflows `", stringify!($i), "`.")]
         #[inline]
+        #[track_caller]
         pub const fn $from_unital(val: $i) -> Self {
-            // Compile-time/runtime check - will fail if constants don't fit in target type
             const {
                 assert!(
                     Helpers::<$nom, $denum, NOM, DENOM>::RD_TIMES_LN <= <$i>::MAX as u64,
@@ -83,7 +99,10 @@ macro_rules! shorthand {
                 );
             }
 
-            let mul = Helpers::<$nom, $denum, NOM, DENOM>::RD_TIMES_LN as $i * val;
+            let mul = const_checked!(
+                (Helpers::<$nom, $denum, NOM, DENOM>::RD_TIMES_LN as $i).checked_mul(val),
+                concat!("Duration::", stringify!($from_unital), ": multiplication overflowed storage type")
+            );
             let ld_times_rn = Helpers::<$nom, $denum, NOM, DENOM>::LD_TIMES_RN as $i;
             Self::from_ticks(mul.div_ceil(ld_times_rn))
         }
@@ -496,8 +515,10 @@ macro_rules! impl_duration_for_integer {
                     if let Some(lh) = (duration.ticks as u64)
                         .checked_mul(Helpers::<I_NOM, I_DENOM, NOM, DENOM>::RD_TIMES_LN)
                     {
-                        let ticks = (lh + Helpers::<I_NOM, I_DENOM, NOM, DENOM>::LD_TIMES_RN / 2)
-                            / Helpers::<I_NOM, I_DENOM, NOM, DENOM>::LD_TIMES_RN;
+                        let ticks = div_round_nearest_u64(
+                            lh,
+                            Helpers::<I_NOM, I_DENOM, NOM, DENOM>::LD_TIMES_RN,
+                        );
 
                         if ticks <= <$i>::MAX as u64 {
                             Some(Self::from_ticks(ticks as $i))
@@ -568,6 +589,12 @@ macro_rules! impl_duration_for_integer {
             pub const fn try_from_rate<const I_NOM: u64, const I_DENOM: u64>(
                 rate: Rate<$i, I_NOM, I_DENOM>,
             ) -> Option<Self> {
+                const {
+                    assert!(
+                        Helpers::<I_NOM, I_DENOM, NOM, DENOM>::RATE_TO_DURATION_NUMERATOR <= <$i>::MAX as u64,
+                        concat!("RATE_TO_DURATION_NUMERATOR doesn't fit in ", stringify!($i), " for this Rate/Duration combination")
+                    );
+                }
                 if rate.raw > 0 {
                     Some(Self::from_ticks(
                         Helpers::<I_NOM, I_DENOM, NOM, DENOM>::RATE_TO_DURATION_NUMERATOR as $i

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -793,6 +793,7 @@ macro_rules! impl_duration_for_integer {
         impl<const NOM: u64, const DENOM: u64> ops::SubAssign for Duration<$i, NOM, DENOM>
         {
             #[inline]
+            #[track_caller]
             fn sub_assign(&mut self, other: Self) {
                 *self = *self - other;
             }
@@ -819,6 +820,7 @@ macro_rules! impl_duration_for_integer {
         impl<const NOM: u64, const DENOM: u64> ops::AddAssign for Duration<$i, NOM, DENOM>
         {
             #[inline]
+            #[track_caller]
             fn add_assign(&mut self, other: Self) {
                 *self = *self + other;
             }
@@ -829,6 +831,7 @@ macro_rules! impl_duration_for_integer {
             type Output = Duration<$i, NOM, DENOM>;
 
             #[inline]
+            #[track_caller]
             fn mul(self, mut other: Duration<$i, NOM, DENOM>) -> Self::Output {
                 other.ticks *= self as $i;
                 other
@@ -840,6 +843,7 @@ macro_rules! impl_duration_for_integer {
             type Output = Self;
 
             #[inline]
+            #[track_caller]
             fn mul(mut self, other: u32) -> Self::Output {
                 self.ticks *= other as $i;
                 self
@@ -851,6 +855,7 @@ macro_rules! impl_duration_for_integer {
             for Duration<$i, NOM, DENOM>
         {
             #[inline]
+            #[track_caller]
             fn mul_assign(&mut self, other: u32) {
                 *self = *self * other;
             }
@@ -861,6 +866,7 @@ macro_rules! impl_duration_for_integer {
             type Output = Self;
 
             #[inline]
+            #[track_caller]
             fn div(mut self, other: u32) -> Self::Output {
                 self.ticks /= other as $i;
                 self
@@ -872,6 +878,7 @@ macro_rules! impl_duration_for_integer {
             for Duration<$i, NOM, DENOM>
         {
             #[inline]
+            #[track_caller]
             fn div_assign(&mut self, other: u32) {
                 *self = *self / other;
             }
@@ -898,6 +905,7 @@ macro_rules! impl_duration_for_integer {
         impl<const NOM: u64, const DENOM: u64> ops::RemAssign for Duration<$i, NOM, DENOM>
         {
             #[inline]
+            #[track_caller]
             fn rem_assign(&mut self, other: Self) {
                 *self = *self % other;
             }
@@ -1069,6 +1077,7 @@ impl<const NOM: u64, const DENOM: u64> ops::SubAssign<Duration<u32, NOM, DENOM>>
     for Duration<u64, NOM, DENOM>
 {
     #[inline]
+    #[track_caller]
     fn sub_assign(&mut self, other: Duration<u32, NOM, DENOM>) {
         *self = *self - other;
     }
@@ -1097,6 +1106,7 @@ impl<const NOM: u64, const DENOM: u64> ops::AddAssign<Duration<u32, NOM, DENOM>>
     for Duration<u64, NOM, DENOM>
 {
     #[inline]
+    #[track_caller]
     fn add_assign(&mut self, other: Duration<u32, NOM, DENOM>) {
         *self = *self + other;
     }

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -175,7 +175,9 @@ macro_rules! impl_duration_for_integer {
                 self.ticks == 0
             }
 
-            /// Add two durations while checking for overflow.
+            /// Add two durations.
+            ///
+            /// Returns `None` on tick overflow or cross-base conversion overflow.
             ///
             /// ```
             /// # use fugit::*;
@@ -214,7 +216,9 @@ macro_rules! impl_duration_for_integer {
                 }
             }
 
-            /// Subtract two durations while checking for overflow.
+            /// Subtract two durations.
+            ///
+            /// Returns `None` on tick underflow or cross-base conversion overflow.
             ///
             /// ```
             /// # use fugit::*;
@@ -289,7 +293,9 @@ macro_rules! impl_duration_for_integer {
                 }
             }
 
-            /// Get the remainder of dividing two durations while checking for divide-by-zero.
+            /// Remainder of dividing two durations.
+            ///
+            /// Returns `None` if `other` is zero or the cross-base conversion overflows.
             ///
             /// ```
             /// # use fugit::*;
@@ -418,6 +424,9 @@ macro_rules! impl_duration_for_integer {
 
             /// Const partial comparison.
             ///
+            /// Returns `None` if either side's tick value cannot be expressed in
+            /// the common base without overflowing the storage type.
+            ///
             /// ```
             /// # use fugit::*;
             #[doc = concat!("let d1 = Duration::<", stringify!($i), ", 1, 100>::from_ticks(1);")]
@@ -465,6 +474,9 @@ macro_rules! impl_duration_for_integer {
             }
 
             /// Const equality check.
+            ///
+            /// Returns `false` (rather than panicking) if the cross-base
+            /// conversion overflows the storage type.
             ///
             /// ```
             /// # use fugit::*;
@@ -547,7 +559,7 @@ macro_rules! impl_duration_for_integer {
                 Duration::<$i, O_NOM, O_DENOM>::const_try_from(self)
             }
 
-            /// Const try into rate, checking for divide-by-zero.
+            /// Convert to a rate. Returns `None` if this duration is zero.
             ///
             /// ```
             /// # use fugit::*;
@@ -563,7 +575,7 @@ macro_rules! impl_duration_for_integer {
                 Rate::<$i, O_NOM, O_DENOM>::try_from_duration(self)
             }
 
-            /// Convert from duration to rate.
+            /// Convert to a rate. Panics if this duration is zero.
             #[inline]
             #[track_caller]
             pub const fn to_rate<const O_NOM: u64, const O_DENOM: u64>(
@@ -576,7 +588,7 @@ macro_rules! impl_duration_for_integer {
                 }
             }
 
-            /// Const try from rate, checking for divide-by-zero.
+            /// Convert from a rate. Returns `None` if the rate is zero.
             ///
             /// ```
             /// # use fugit::*;
@@ -605,7 +617,7 @@ macro_rules! impl_duration_for_integer {
                 }
             }
 
-            /// Convert from rate to duration.
+            /// Convert from a rate. Panics if the rate is zero.
             #[inline]
             #[track_caller]
             pub const fn from_rate<const I_NOM: u64, const I_DENOM: u64>(
@@ -708,22 +720,25 @@ macro_rules! impl_duration_for_integer {
                 Self::from_ticks((secs * factor + 0.5) as $i)
             }
 
-            /// Shorthand for creating a duration which represents hertz.
+            /// Period of a hertz rate. Panics if `val` is zero.
             #[inline]
+            #[track_caller]
             #[allow(non_snake_case)]
             pub const fn Hz(val: $i) -> Self {
                 Self::from_rate(crate::Hertz::<$i>::from_raw(val))
             }
 
-            /// Shorthand for creating a duration which represents kilohertz.
+            /// Period of a kilohertz rate. Panics if `val` is zero.
             #[inline]
+            #[track_caller]
             #[allow(non_snake_case)]
             pub const fn kHz(val: $i) -> Self {
                 Self::from_rate(crate::Kilohertz::<$i>::from_raw(val))
             }
 
-            /// Shorthand for creating a duration which represents megahertz.
+            /// Period of a megahertz rate. Panics if `val` is zero.
             #[inline]
+            #[track_caller]
             #[allow(non_snake_case)]
             pub const fn MHz(val: $i) -> Self {
                 Self::from_rate(crate::Megahertz::<$i>::from_raw(val))

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -75,3 +75,27 @@ impl<const L_NOM: u64, const L_DENOM: u64, const R_NOM: u64, const R_DENOM: u64>
     /// Helper constants generated at compile time
     pub const SAME_BASE: bool = Self::LD_TIMES_RN == Self::RD_TIMES_LN;
 }
+
+/// Compute `numerator / divisor` rounded to nearest, half-up, without overflow.
+///
+/// Equivalent to `(numerator + divisor / 2) / divisor` when the latter does not
+/// overflow, but stays correct when `numerator` is close to `u64::MAX` (where
+/// adding `divisor / 2` would wrap). `divisor` must be `> 0`.
+///
+/// This is the embedded-friendly form: a single `u64` divmod plus a couple of
+/// cheap 32-bit ops. On 32-bit cores (Cortex-M, RISC-V32) it avoids pulling in
+/// the `u128` libgcc routines that the alternative `(u128 + d/2) / d` shape
+/// would require.
+#[inline]
+pub const fn div_round_nearest_u64(numerator: u64, divisor: u64) -> u64 {
+    let q = numerator / divisor;
+    let r = numerator % divisor;
+    // `r >= d - r` is equivalent to `2 * r >= d` but never overflows because
+    // `r < d`. When d == 1, r is always 0 so the branch is never taken; when
+    // d >= 2, q <= u64::MAX / 2, so `q + 1` cannot overflow either.
+    if r >= divisor - r {
+        q + 1
+    } else {
+        q
+    }
+}

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -289,6 +289,7 @@ macro_rules! impl_instant_for_integer {
             for Instant<$i, NOM, DENOM>
         {
             #[inline]
+            #[track_caller]
             fn sub_assign(&mut self, other: Duration<$i, NOM, DENOM>) {
                 *self = *self - other;
             }
@@ -322,6 +323,7 @@ macro_rules! impl_instant_for_integer {
             for Instant<$i, NOM, DENOM>
         {
             #[inline]
+            #[track_caller]
             fn add_assign(&mut self, other: Duration<$i, NOM, DENOM>) {
                 *self = *self + other;
             }
@@ -405,6 +407,7 @@ impl<const NOM: u64, const DENOM: u64> ops::SubAssign<Duration<u32, NOM, DENOM>>
     for Instant<u64, NOM, DENOM>
 {
     #[inline]
+    #[track_caller]
     fn sub_assign(&mut self, other: Duration<u32, NOM, DENOM>) {
         *self = *self - other;
     }
@@ -438,6 +441,7 @@ impl<const NOM: u64, const DENOM: u64> ops::AddAssign<Duration<u32, NOM, DENOM>>
     for Instant<u64, NOM, DENOM>
 {
     #[inline]
+    #[track_caller]
     fn add_assign(&mut self, other: Duration<u32, NOM, DENOM>) {
         *self = *self + other;
     }

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -102,6 +102,11 @@ macro_rules! impl_instant_for_integer {
 
             /// Duration between `Instant`s.
             ///
+            /// Returns `None` if `self` is before `other` under the wrap-aware
+            /// ordering used by [`const_cmp`](Self::const_cmp): if `self` and
+            /// `other` differ by more than half the tick range, the result is
+            /// reversed.
+            ///
             /// ```
             /// # use fugit::*;
             #[doc = concat!("let i1 = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
@@ -125,7 +130,11 @@ macro_rules! impl_instant_for_integer {
                 }
             }
 
-            /// Subtract a `Duration` from an `Instant` while checking for overflow.
+            /// Subtract a `Duration` from an `Instant`.
+            ///
+            /// The tick subtraction itself wraps (Instants are circular). Returns
+            /// `None` only when converting `other` into this Instant's base
+            /// overflows.
             ///
             /// ```
             /// # use fugit::*;
@@ -156,7 +165,11 @@ macro_rules! impl_instant_for_integer {
                 }
             }
 
-            /// Add a `Duration` to an `Instant` while checking for overflow.
+            /// Add a `Duration` to an `Instant`.
+            ///
+            /// The tick addition itself wraps (Instants are circular). Returns
+            /// `None` only when converting `other` into this Instant's base
+            /// overflows.
             ///
             /// ```
             /// # use fugit::*;

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -1,4 +1,4 @@
-use crate::helpers::Helpers;
+use crate::helpers::{div_round_nearest_u64, Helpers};
 use crate::Duration;
 use core::cmp::Ordering;
 use core::convert;
@@ -16,6 +16,49 @@ use core::ops;
 #[derive(Clone, Copy, Debug)]
 pub struct Rate<T, const NOM: u64, const DENOM: u64> {
     pub(crate) raw: T,
+}
+
+// Unwrap a const-time `Option` or panic with the given static message. Lets the
+// shorthand methods turn `checked_mul`/`checked_add` failures into a clear panic
+// at the user's call site instead of silently wrapping in release builds.
+macro_rules! const_checked {
+    ($e:expr, $msg:expr) => {
+        match $e {
+            Some(v) => v,
+            None => panic!("{}", $msg),
+        }
+    };
+}
+
+// Compile-time assert that the helper constants for (l_nom, l_denom, NOM, DENOM)
+// fit in `$i`. The Hz/kHz/MHz/to_Hz/to_kHz/to_MHz shorthands cast both constants
+// `as $i`; without this check those casts silently truncate when the value fits
+// `u64` but not the target storage type.
+macro_rules! assert_helpers_fit {
+    ($i:ty, $l_nom:literal, $l_denom:literal, $method:literal) => {
+        const {
+            assert!(
+                Helpers::<$l_nom, $l_denom, NOM, DENOM>::LD_TIMES_RN <= <$i>::MAX as u64,
+                concat!(
+                    "LD_TIMES_RN doesn't fit in ",
+                    stringify!($i),
+                    " for ",
+                    $method,
+                    " on this Rate type"
+                )
+            );
+            assert!(
+                Helpers::<$l_nom, $l_denom, NOM, DENOM>::RD_TIMES_LN <= <$i>::MAX as u64,
+                concat!(
+                    "RD_TIMES_LN doesn't fit in ",
+                    stringify!($i),
+                    " for ",
+                    $method,
+                    " on this Rate type"
+                )
+            );
+        }
+    };
 }
 
 macro_rules! impl_rate_for_integer {
@@ -257,9 +300,10 @@ macro_rules! impl_rate_for_integer {
                     if let Some(lh) = (rate.raw as u64)
                         .checked_mul(Helpers::<I_NOM, I_DENOM, NOM, DENOM>::RD_TIMES_LN)
                     {
-                        // Add half of divisor for proper rounding (half-up)
-                        let raw = (lh + Helpers::<I_NOM, I_DENOM, NOM, DENOM>::LD_TIMES_RN / 2)
-                            / Helpers::<I_NOM, I_DENOM, NOM, DENOM>::LD_TIMES_RN;
+                        let raw = div_round_nearest_u64(
+                            lh,
+                            Helpers::<I_NOM, I_DENOM, NOM, DENOM>::LD_TIMES_RN,
+                        );
 
                         if raw <= <$i>::MAX as u64 {
                             Some(Self::from_raw(raw as $i))
@@ -328,6 +372,12 @@ macro_rules! impl_rate_for_integer {
             pub const fn try_from_duration<const I_NOM: u64, const I_DENOM: u64>(
                 duration: Duration<$i, I_NOM, I_DENOM>,
             ) -> Option<Self> {
+                const {
+                    assert!(
+                        Helpers::<I_NOM, I_DENOM, NOM, DENOM>::RATE_TO_DURATION_NUMERATOR <= <$i>::MAX as u64,
+                        concat!("RATE_TO_DURATION_NUMERATOR doesn't fit in ", stringify!($i), " for this Duration/Rate combination")
+                    );
+                }
                 if duration.ticks > 0 {
                     Some(Self::from_raw(
                         Helpers::<I_NOM, I_DENOM, NOM, DENOM>::RATE_TO_DURATION_NUMERATOR as $i
@@ -384,60 +434,105 @@ macro_rules! impl_rate_for_integer {
             }
 
             /// Convert the Rate to an interger number of Hz.
+            ///
+            /// Panics if the result overflows the storage type.
             #[inline]
+            #[track_caller]
             #[allow(non_snake_case)]
             pub const fn to_Hz(&self) -> $i {
-                    (Helpers::<1, 1, NOM, DENOM>::LD_TIMES_RN as $i * self.raw
-                        + Helpers::<1, 1, NOM, DENOM>::RD_TIMES_LN as $i / 2)
-                        / Helpers::<1, 1, NOM, DENOM>::RD_TIMES_LN as $i
+                assert_helpers_fit!($i, 1, 1, "to_Hz");
+                let prod = const_checked!(
+                    (Helpers::<1, 1, NOM, DENOM>::LD_TIMES_RN as $i).checked_mul(self.raw),
+                    "Rate::to_Hz: multiplication overflowed storage type"
+                );
+                let sum = const_checked!(
+                    prod.checked_add(Helpers::<1, 1, NOM, DENOM>::RD_TIMES_LN as $i / 2),
+                    "Rate::to_Hz: rounding addition overflowed storage type"
+                );
+                sum / Helpers::<1, 1, NOM, DENOM>::RD_TIMES_LN as $i
             }
 
             /// Convert the Rate to an interger number of kHz.
+            ///
+            /// Panics if the result overflows the storage type.
             #[inline]
+            #[track_caller]
             #[allow(non_snake_case)]
             pub const fn to_kHz(&self) -> $i {
-                    (Helpers::<1_000, 1, NOM, DENOM>::LD_TIMES_RN as $i * self.raw
-                        + Helpers::<1_000, 1, NOM, DENOM>::RD_TIMES_LN as $i / 2)
-                        / Helpers::<1_000, 1, NOM, DENOM>::RD_TIMES_LN as $i
+                assert_helpers_fit!($i, 1_000, 1, "to_kHz");
+                let prod = const_checked!(
+                    (Helpers::<1_000, 1, NOM, DENOM>::LD_TIMES_RN as $i).checked_mul(self.raw),
+                    "Rate::to_kHz: multiplication overflowed storage type"
+                );
+                let sum = const_checked!(
+                    prod.checked_add(Helpers::<1_000, 1, NOM, DENOM>::RD_TIMES_LN as $i / 2),
+                    "Rate::to_kHz: rounding addition overflowed storage type"
+                );
+                sum / Helpers::<1_000, 1, NOM, DENOM>::RD_TIMES_LN as $i
             }
 
             /// Convert the Rate to an interger number of MHz.
+            ///
+            /// Panics if the result overflows the storage type.
             #[inline]
+            #[track_caller]
             #[allow(non_snake_case)]
             pub const fn to_MHz(&self) -> $i {
-                    (Helpers::<1_000_000, 1, NOM, DENOM>::LD_TIMES_RN as $i * self.raw
-                        + Helpers::<1_000_000, 1, NOM, DENOM>::RD_TIMES_LN as $i / 2)
-                        / Helpers::<1_000_000, 1, NOM, DENOM>::RD_TIMES_LN as $i
+                assert_helpers_fit!($i, 1_000_000, 1, "to_MHz");
+                let prod = const_checked!(
+                    (Helpers::<1_000_000, 1, NOM, DENOM>::LD_TIMES_RN as $i).checked_mul(self.raw),
+                    "Rate::to_MHz: multiplication overflowed storage type"
+                );
+                let sum = const_checked!(
+                    prod.checked_add(Helpers::<1_000_000, 1, NOM, DENOM>::RD_TIMES_LN as $i / 2),
+                    "Rate::to_MHz: rounding addition overflowed storage type"
+                );
+                sum / Helpers::<1_000_000, 1, NOM, DENOM>::RD_TIMES_LN as $i
             }
 
             /// Shorthand for creating a rate which represents hertz.
+            ///
+            /// Panics if the resulting raw value overflows the storage type.
             #[inline]
+            #[track_caller]
             #[allow(non_snake_case)]
             pub const fn Hz(val: $i) -> Self {
-                Self::from_raw(
-                    (Helpers::<1, 1, NOM, DENOM>::RD_TIMES_LN as $i * val)
-                        / Helpers::<1, 1, NOM, DENOM>::LD_TIMES_RN as $i,
-                )
+                assert_helpers_fit!($i, 1, 1, "Hz");
+                let prod = const_checked!(
+                    (Helpers::<1, 1, NOM, DENOM>::RD_TIMES_LN as $i).checked_mul(val),
+                    "Rate::Hz: multiplication overflowed storage type"
+                );
+                Self::from_raw(prod / Helpers::<1, 1, NOM, DENOM>::LD_TIMES_RN as $i)
             }
 
             /// Shorthand for creating a rate which represents kilohertz.
+            ///
+            /// Panics if the resulting raw value overflows the storage type.
             #[inline]
+            #[track_caller]
             #[allow(non_snake_case)]
             pub const fn kHz(val: $i) -> Self {
-                Self::from_raw(
-                    (Helpers::<1_000, 1, NOM, DENOM>::RD_TIMES_LN as $i * val)
-                        / Helpers::<1_000, 1, NOM, DENOM>::LD_TIMES_RN as $i,
-                )
+                assert_helpers_fit!($i, 1_000, 1, "kHz");
+                let prod = const_checked!(
+                    (Helpers::<1_000, 1, NOM, DENOM>::RD_TIMES_LN as $i).checked_mul(val),
+                    "Rate::kHz: multiplication overflowed storage type"
+                );
+                Self::from_raw(prod / Helpers::<1_000, 1, NOM, DENOM>::LD_TIMES_RN as $i)
             }
 
             /// Shorthand for creating a rate which represents megahertz.
+            ///
+            /// Panics if the resulting raw value overflows the storage type.
             #[inline]
+            #[track_caller]
             #[allow(non_snake_case)]
             pub const fn MHz(val: $i) -> Self {
-                Self::from_raw(
-                    (Helpers::<1_000_000, 1, NOM, DENOM>::RD_TIMES_LN as $i * val)
-                        / Helpers::<1_000_000, 1, NOM, DENOM>::LD_TIMES_RN as $i,
-                )
+                assert_helpers_fit!($i, 1_000_000, 1, "MHz");
+                let prod = const_checked!(
+                    (Helpers::<1_000_000, 1, NOM, DENOM>::RD_TIMES_LN as $i).checked_mul(val),
+                    "Rate::MHz: multiplication overflowed storage type"
+                );
+                Self::from_raw(prod / Helpers::<1_000_000, 1, NOM, DENOM>::LD_TIMES_RN as $i)
             }
 
             /// Shorthand for creating a rate which represents nanoseconds.

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -630,10 +630,21 @@ macro_rules! impl_rate_for_integer {
             }
         }
 
+        // Rate -= Rate
+        impl<const NOM: u64, const DENOM: u64> ops::SubAssign for Rate<$i, NOM, DENOM>
+        {
+            #[inline]
+            #[track_caller]
+            fn sub_assign(&mut self, other: Self) {
+                *self = *self - other;
+            }
+        }
+
         // Rate += Rate
         impl<const NOM: u64, const DENOM: u64> ops::AddAssign for Rate<$i, NOM, DENOM>
         {
             #[inline]
+            #[track_caller]
             fn add_assign(&mut self, other: Self) {
                 *self = *self + other;
             }
@@ -644,6 +655,7 @@ macro_rules! impl_rate_for_integer {
             type Output = Rate<$i, NOM, DENOM>;
 
             #[inline]
+            #[track_caller]
             fn mul(self, mut other: Rate<$i, NOM, DENOM>) -> Self::Output {
                 other.raw *= self as $i;
                 other
@@ -655,6 +667,7 @@ macro_rules! impl_rate_for_integer {
             type Output = Self;
 
             #[inline]
+            #[track_caller]
             fn mul(mut self, other: u32) -> Self::Output {
                 self.raw *= other as $i;
                 self
@@ -666,6 +679,7 @@ macro_rules! impl_rate_for_integer {
             for Rate<$i, NOM, DENOM>
         {
             #[inline]
+            #[track_caller]
             fn mul_assign(&mut self, other: u32) {
                 *self = *self * other;
             }
@@ -676,6 +690,7 @@ macro_rules! impl_rate_for_integer {
             type Output = Self;
 
             #[inline]
+            #[track_caller]
             fn div(mut self, other: u32) -> Self::Output {
                 self.raw /= other as $i;
                 self
@@ -701,6 +716,7 @@ macro_rules! impl_rate_for_integer {
             for Rate<$i, NOM, DENOM>
         {
             #[inline]
+            #[track_caller]
             fn div_assign(&mut self, other: u32) {
                 *self = *self / other;
             }
@@ -727,6 +743,7 @@ macro_rules! impl_rate_for_integer {
         impl<const NOM: u64, const DENOM: u64> ops::RemAssign for Rate<$i, NOM, DENOM>
         {
             #[inline]
+            #[track_caller]
             fn rem_assign(&mut self, other: Self) {
                 *self = *self % other;
             }
@@ -817,6 +834,7 @@ impl<const NOM: u64, const DENOM: u64> ops::SubAssign<Rate<u32, NOM, DENOM>>
     for Rate<u64, NOM, DENOM>
 {
     #[inline]
+    #[track_caller]
     fn sub_assign(&mut self, other: Rate<u32, NOM, DENOM>) {
         *self = *self - other;
     }
@@ -844,6 +862,7 @@ impl<const NOM: u64, const DENOM: u64> ops::AddAssign<Rate<u32, NOM, DENOM>>
     for Rate<u64, NOM, DENOM>
 {
     #[inline]
+    #[track_caller]
     fn add_assign(&mut self, other: Rate<u32, NOM, DENOM>) {
         *self = *self + other;
     }

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -91,7 +91,9 @@ macro_rules! impl_rate_for_integer {
                 self.raw
             }
 
-            /// Add two rates while checking for overflow.
+            /// Add two rates.
+            ///
+            /// Returns `None` on raw overflow or cross-base conversion overflow.
             ///
             /// ```
             /// # use fugit::*;
@@ -130,7 +132,9 @@ macro_rules! impl_rate_for_integer {
                 }
             }
 
-            /// Subtract two rates while checking for overflow.
+            /// Subtract two rates.
+            ///
+            /// Returns `None` on raw underflow or cross-base conversion overflow.
             ///
             /// ```
             /// # use fugit::*;
@@ -169,7 +173,9 @@ macro_rules! impl_rate_for_integer {
                 }
             }
 
-            /// Get the remainder of dividing two rates while checking for divide-by-zero.
+            /// Remainder of dividing two rates.
+            ///
+            /// Returns `None` if `other` is zero or the cross-base conversion overflows.
             ///
             /// ```
             /// # use fugit::*;
@@ -218,6 +224,9 @@ macro_rules! impl_rate_for_integer {
 
             /// Const partial comparison.
             ///
+            /// Returns `None` if either side's raw value cannot be expressed in
+            /// the common base without overflowing the storage type.
+            ///
             /// ```
             /// # use fugit::*;
             #[doc = concat!("let r1 = Rate::<", stringify!($i), ", 1, 1_00>::from_raw(1);")]
@@ -250,6 +259,9 @@ macro_rules! impl_rate_for_integer {
             }
 
             /// Const equality check.
+            ///
+            /// Returns `false` (rather than panicking) if the cross-base
+            /// conversion overflows the storage type.
             ///
             /// ```
             /// # use fugit::*;
@@ -332,7 +344,7 @@ macro_rules! impl_rate_for_integer {
                 Rate::<$i, O_NOM, O_DENOM>::const_try_from(self)
             }
 
-            /// Const try into duration, checking for divide-by-zero.
+            /// Convert to a duration. Returns `None` if this rate is zero.
             ///
             /// ```
             /// # use fugit::*;
@@ -347,7 +359,7 @@ macro_rules! impl_rate_for_integer {
                 Duration::<$i, O_NOM, O_DENOM>::try_from_rate(self)
             }
 
-            /// Convert from rate to duration.
+            /// Convert to a duration. Panics if this rate is zero.
             #[track_caller]
             pub const fn to_duration<const O_NOM: u64, const O_DENOM: u64>(
                 self,
@@ -359,7 +371,7 @@ macro_rules! impl_rate_for_integer {
                 }
             }
 
-            /// Const try from duration, checking for divide-by-zero.
+            /// Convert from a duration. Returns `None` if the duration is zero.
             ///
             /// ```
             /// # use fugit::*;
@@ -388,7 +400,7 @@ macro_rules! impl_rate_for_integer {
                 }
             }
 
-            /// Convert from duration to rate.
+            /// Convert from a duration. Panics if the duration is zero.
             #[inline]
             #[track_caller]
             pub const fn from_duration<const I_NOM: u64, const I_DENOM: u64>(
@@ -535,20 +547,23 @@ macro_rules! impl_rate_for_integer {
                 Self::from_raw(prod / Helpers::<1_000_000, 1, NOM, DENOM>::LD_TIMES_RN as $i)
             }
 
-            /// Shorthand for creating a rate which represents nanoseconds.
+            /// Rate from a nanosecond period. Panics if `val` is zero.
             #[inline]
+            #[track_caller]
             pub const fn nanos(val: $i) -> Self {
                 Self::from_duration(crate::Duration::<$i, 1, 1_000_000_000>::from_ticks(val))
             }
 
-            /// Shorthand for creating a rate which represents microseconds.
+            /// Rate from a microsecond period. Panics if `val` is zero.
             #[inline]
+            #[track_caller]
             pub const fn micros(val: $i) -> Self {
                 Self::from_duration(crate::Duration::<$i, 1, 1_000_000>::from_ticks(val))
             }
 
-            /// Shorthand for creating a rate which represents milliseconds.
+            /// Rate from a millisecond period. Panics if `val` is zero.
             #[inline]
+            #[track_caller]
             pub const fn millis(val: $i) -> Self {
                 Self::from_duration(crate::Duration::<$i, 1, 1_000>::from_ticks(val))
             }

--- a/src/test_duration.rs
+++ b/src/test_duration.rs
@@ -941,3 +941,89 @@ fn duration_into_core_duration() {
     assert_eq!(back.as_secs(), 10);
     assert_eq!(back.subsec_nanos(), 250_000_000);
 }
+
+#[test]
+fn duration_const_try_from_no_rounding_overflow_u64() {
+    // Regression: previously the rounding step `lh + LD_TIMES_RN/2` overflowed
+    // u64 silently when ticks were close to u64::MAX, producing Some(garbage)
+    // instead of either the correct value or None.
+
+    // u64::MAX milliseconds to seconds. lh = u64::MAX, divisor = 1000,
+    // remainder 615 so it rounds up.
+    let big_ms = Duration::<u64, 1, 1_000>::from_ticks(u64::MAX);
+    let secs: Option<Duration<u64, 1, 1>> = big_ms.const_try_into();
+    assert_eq!(secs.unwrap().as_ticks(), u64::MAX / 1000 + 1);
+
+    // u64::MAX nanoseconds to microseconds, same divisor.
+    let big_ns = Duration::<u64, 1, 1_000_000_000>::from_ticks(u64::MAX);
+    let us: Option<Duration<u64, 1, 1_000_000>> = big_ns.const_try_into();
+    assert_eq!(us.unwrap().as_ticks(), u64::MAX / 1000 + 1);
+
+    // u64::MAX nanoseconds to seconds. divisor = 1_000_000_000.
+    let big_ns = Duration::<u64, 1, 1_000_000_000>::from_ticks(u64::MAX);
+    let s: Option<Duration<u64, 1, 1>> = big_ns.const_try_into();
+    // u64::MAX / 1_000_000_000 = 18_446_744_073, remainder 709_551_615
+    // (above half), so result rounds up by one.
+    assert_eq!(s.unwrap().as_ticks(), u64::MAX / 1_000_000_000 + 1);
+
+    // Half-down case: r strictly below half should not round up.
+    let d = 1_000u64;
+    let q = (u64::MAX / d) - 1;
+    let r = d / 2 - 1;
+    let ticks = q * d + r;
+    let dur = Duration::<u64, 1, 1_000>::from_ticks(ticks);
+    let secs: Option<Duration<u64, 1, 1>> = dur.const_try_into();
+    assert_eq!(secs.unwrap().as_ticks(), q);
+
+    // Half-up case: r = d/2 should round up.
+    let r = d / 2;
+    let ticks = q * d + r;
+    let dur = Duration::<u64, 1, 1_000>::from_ticks(ticks);
+    let secs: Option<Duration<u64, 1, 1>> = dur.const_try_into();
+    assert_eq!(secs.unwrap().as_ticks(), q + 1);
+}
+
+#[test]
+fn duration_const_try_from_returns_none_on_target_overflow() {
+    // When the rounded result genuinely doesn't fit the target type, the
+    // function must return None (it must not silently truncate).
+
+    // u32::MAX ms to seconds: u32::MAX % 1000 = 295 (below half), no round-up.
+    let many_ms = Duration::<u32, 1, 1_000>::from_ticks(u32::MAX);
+    let secs: Option<Duration<u32, 1, 1>> = many_ms.const_try_into();
+    assert_eq!(secs.unwrap().as_ticks(), u32::MAX / 1000);
+
+    // u64::MAX ms to seconds in u32: clearly doesn't fit, must be None.
+    // (Conversion from u64 Duration into u32 Duration via try_from chain.)
+    let big = Duration::<u64, 1, 1_000>::from_ticks(u64::MAX);
+    let as_u64_s: Duration<u64, 1, 1> = big.convert();
+    let as_u32: Result<Duration<u32, 1, 1>, _> = as_u64_s.try_into();
+    assert!(as_u32.is_err());
+}
+
+#[test]
+#[should_panic(expected = "Duration::as_picos: multiplication overflowed storage type")]
+fn duration_as_unit_panics_on_runtime_overflow_u32() {
+    // Regression: shorthand methods used to silently wrap on overflow.
+    // u32::MAX microseconds as picoseconds = u32::MAX * 1_000_000, overflows u32.
+    let d = Duration::<u32, 1, 1_000_000>::from_ticks(u32::MAX);
+    let _ = d.as_picos();
+}
+
+#[test]
+#[should_panic(expected = "Duration::from_minutes: multiplication overflowed storage type")]
+fn duration_from_unit_panics_on_runtime_overflow_u32() {
+    // u32::MAX minutes as a seconds-based Duration: val * 60 overflows u32.
+    let _ = Duration::<u32, 1, 1>::from_minutes(u32::MAX);
+}
+
+#[test]
+fn duration_shorthand_works_for_valid_u32() {
+    // Make sure the const_checked path doesn't break valid uses.
+    let d = Duration::<u32, 1, 1_000>::from_ticks(5_000);
+    assert_eq!(d.as_secs(), 5);
+    assert_eq!(d.as_millis(), 5_000);
+
+    let d = Duration::<u32, 1, 1>::from_ticks(120);
+    assert_eq!(d.as_minutes(), 2);
+}

--- a/src/test_rate.rs
+++ b/src/test_rate.rs
@@ -423,3 +423,45 @@ fn rate_conversion_rounding() {
         "6 Hz should convert exactly to 3 in base 2/1"
     );
 }
+
+#[test]
+fn rate_const_try_from_no_rounding_overflow_u64() {
+    // Regression: previously the rounding step `lh + LD_TIMES_RN/2` overflowed
+    // u64 silently when raw was close to u64::MAX, producing Some(garbage).
+
+    // u64::MAX of (1/1000) base into (1/1) base. RD_TIMES_LN = 1, LD_TIMES_RN
+    // = 1000, lh = u64::MAX, remainder 615 so the answer rounds up.
+    let r1 = Rate::<u64, 1, 1_000>::from_raw(u64::MAX);
+    let r2: Option<Rate<u64, 1, 1>> = r1.const_try_into();
+    assert_eq!(r2.unwrap().to_raw(), u64::MAX / 1000 + 1);
+}
+
+#[test]
+#[should_panic(expected = "Rate::to_Hz: multiplication overflowed storage type")]
+fn rate_to_hz_panics_on_runtime_overflow_u32() {
+    // Regression: 5 GHz expressed as Rate<u32, 1e9, 1>::from_raw(5) used to
+    // silently wrap to 705_032_704 in release. Now it panics.
+    let r = Rate::<u32, 1_000_000_000, 1>::from_raw(5);
+    let _ = r.to_Hz();
+}
+
+#[test]
+fn rate_to_hz_works_for_valid_u32() {
+    // Make sure the const_checked path doesn't break valid uses.
+    let r = Rate::<u32, 1, 1>::from_raw(1_234);
+    assert_eq!(r.to_Hz(), 1_234);
+
+    let r = Rate::<u32, 1_000, 1>::from_raw(2);
+    assert_eq!(r.to_Hz(), 2_000);
+}
+
+#[test]
+#[should_panic(expected = "Rate::Hz: multiplication overflowed storage type")]
+fn rate_hz_constructor_panics_on_runtime_overflow_u32() {
+    // Try to construct 5 GHz in a Rate type whose period (1 raw unit) is 1 Hz:
+    // Rate<u32, 1, 1>::Hz(5_000_000_000) - val itself overflows u32 but use a
+    // different combination that overflows the multiplication.
+    // Rate<u32, 1, 5>::Hz(val): RD_TIMES_LN = 5, so val * 5 must fit u32.
+    // For val = u32::MAX, 5*u32::MAX overflows.
+    let _ = Rate::<u32, 1, 5>::Hz(u32::MAX);
+}


### PR DESCRIPTION
Three classes of silent miscomputation around the storage-type bounds, all now caught at compile time or with a clear runtime panic at the user's call site.

- `const_try_from`/`const_try_into`/`convert`: the round-half-up step `(lh + d/2) / d` overflowed `u64` silently when `lh` was close to `u64::MAX`, returning `Some(garbage)` instead of the correct value or `None`. Replaced with an overflow-free divmod form (`q + 1 if r >= d - r else q`) that is mathematically equivalent on every input the original handled, and stays correct on the inputs it didn't. Single u64 divmod on 32-bit cores rather than the u128 alternative, so no extra libgcc routines pulled in.
- `try_from_rate`/`try_from_duration` and the `Hz`/`kHz`/`MHz` shorthands on both `Duration` and `Rate`, plus `Rate::to_Hz`/`to_kHz`/`to_MHz`, used to silently truncate when the helper constant fit `u64` but not the target storage type. Added `const { assert!(...) }` checks so these become compile-time errors instead.
- `Rate::Hz`/`kHz`/`MHz`/`to_Hz`/`to_kHz`/`to_MHz` and the `Duration` shorthand methods used to silently wrap in release builds when the multiplication overflowed at runtime. Switched to `checked_mul` and `panic!` with `#[track_caller]` so the panic points at the caller. On Cortex-M3/M4/M7 the optimizer lowers the check to `UMULL` + `CBNZ`, costing ~1 extra cycle on the happy path.

Includes regression tests for each fix and folds these into the v0.4.0 release.