### PR TITLE
Rename `checked_{sub, add}_duration` to `convert_{sub, add}_duration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+* Rename `checked_sub_duration` to `convert_sub_duration` and `checked_add_duration` to `convert_add_duration` with improved docs.
+
 ## [v0.4.0] - 2026-05-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `PartialOrd` is kept, so `<`, `>`, `<=` and `>=` are unaffected.
 - **BREAKING**: Issue #84: `Instant::const_cmp` is replaced by `const_partial_cmp`, which returns
   `None` for instants exactly half the tick range apart.
-- Rename `checked_sub_duration` to `convert_sub_duration` and `checked_add_duration` to `convert_add_duration` with improved docs.
+- **BREAKING**: Rename `checked_sub_duration` to `convert_sub_duration` and `checked_add_duration` to `convert_add_duration` with improved docs.
 
 ## [v0.4.0] - 2026-05-06
 

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -145,7 +145,7 @@ macro_rules! impl_instant_for_integer {
             #[doc = concat!("let i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
             #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
             ///
-            /// assert_eq!(i.checked_sub_duration(d).unwrap().as_ticks(), 0);
+            /// assert_eq!(i.convert_sub_duration(d).unwrap().as_ticks(), 0);
             /// ```
             ///
             /// The subtraction itself is wrapping:
@@ -155,7 +155,7 @@ macro_rules! impl_instant_for_integer {
             #[doc = concat!("let i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
             #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 1_000>::from_ticks(2);")]
             ///
-            #[doc = concat!("assert_eq!(i.checked_sub_duration(d).unwrap().as_ticks(), ", stringify!($i), "::MAX);")]
+            #[doc = concat!("assert_eq!(i.convert_sub_duration(d).unwrap().as_ticks(), ", stringify!($i), "::MAX);")]
             /// ```
             ///
             /// Overflow during [`Duration`] base conversion returns `None`:
@@ -167,9 +167,9 @@ macro_rules! impl_instant_for_integer {
             /// // will overflow.
             #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 500>::from_ticks(", stringify!($i),"::MAX / 2 + 1);")]
             ///
-            /// assert_eq!(i.checked_sub_duration(d), None);
+            /// assert_eq!(i.convert_sub_duration(d), None);
             /// ```
-            pub const fn checked_sub_duration<const O_NOM: u64, const O_DENOM: u64>(
+            pub const fn convert_sub_duration<const O_NOM: u64, const O_DENOM: u64>(
                 self,
                 other: Duration<$i, O_NOM, O_DENOM>,
             ) -> Option<Self> {
@@ -205,7 +205,7 @@ macro_rules! impl_instant_for_integer {
             #[doc = concat!("let i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
             #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
             ///
-            /// assert_eq!(i.checked_add_duration(d).unwrap().as_ticks(), 2);
+            /// assert_eq!(i.convert_add_duration(d).unwrap().as_ticks(), 2);
             /// ```
             ///
             /// The addition itself is wrapping:
@@ -215,7 +215,7 @@ macro_rules! impl_instant_for_integer {
             #[doc = concat!("let i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
             #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 1_000>::from_ticks(", stringify!($i), "::MAX);")]
             ///
-            /// assert_eq!(i.checked_add_duration(d).unwrap().as_ticks(), 0);
+            /// assert_eq!(i.convert_add_duration(d).unwrap().as_ticks(), 0);
             /// ```
             ///
             /// Overflow during [`Duration`] base conversion returns `None`:
@@ -227,9 +227,9 @@ macro_rules! impl_instant_for_integer {
             /// // will overflow.
             #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 500>::from_ticks(", stringify!($i),"::MAX / 2 + 1);")]
             ///
-            /// assert_eq!(i.checked_add_duration(d), None);
+            /// assert_eq!(i.convert_add_duration(d), None);
             /// ```
-            pub const fn checked_add_duration<const O_NOM: u64, const O_DENOM: u64>(
+            pub const fn convert_add_duration<const O_NOM: u64, const O_DENOM: u64>(
                 self,
                 other: Duration<$i, O_NOM, O_DENOM>,
             ) -> Option<Self> {
@@ -315,7 +315,7 @@ macro_rules! impl_instant_for_integer {
         // Instant - Duration = Instant
         // We have limited this to use same numerator and denominator in both left and right hand sides,
         // this allows for the extension traits to work. For usage with different fraction, use
-        // `checked_sub_duration`.
+        // [`Self::convert_sub_duration`].
         impl<const NOM: u64, const DENOM: u64> ops::Sub<Duration<$i, NOM, DENOM>>
             for Instant<$i, NOM, DENOM>
         {
@@ -324,7 +324,7 @@ macro_rules! impl_instant_for_integer {
             #[inline]
             #[track_caller]
             fn sub(self, other: Duration<$i, NOM, DENOM>) -> Self::Output {
-                if let Some(v) = self.checked_sub_duration(other) {
+                if let Some(v) = self.convert_sub_duration(other) {
                     v
                 } else {
                     panic!("Sub failed! Overflow");
@@ -335,7 +335,7 @@ macro_rules! impl_instant_for_integer {
         // Instant -= Duration
         // We have limited this to use same numerator and denominator in both left and right hand sides,
         // this allows for the extension traits to work. For usage with different fraction, use
-        // `checked_sub_duration`.
+        // [`Self::convert_sub_duration`].
         impl<const NOM: u64, const DENOM: u64> ops::SubAssign<Duration<$i, NOM, DENOM>>
             for Instant<$i, NOM, DENOM>
         {
@@ -349,7 +349,7 @@ macro_rules! impl_instant_for_integer {
         // Instant + Duration = Instant
         // We have limited this to use same numerator and denominator in both left and right hand sides,
         // this allows for the extension traits to work. For usage with different fraction, use
-        // `checked_add_duration`.
+        // [`Self::convert_add_duration`].
         impl<const NOM: u64, const DENOM: u64> ops::Add<Duration<$i, NOM, DENOM>>
             for Instant<$i, NOM, DENOM>
         {
@@ -358,7 +358,7 @@ macro_rules! impl_instant_for_integer {
             #[inline]
             #[track_caller]
             fn add(self, other: Duration<$i, NOM, DENOM>) -> Self::Output {
-                if let Some(v) = self.checked_add_duration(other) {
+                if let Some(v) = self.convert_add_duration(other) {
                     v
                 } else {
                     panic!("Add failed! Overflow");
@@ -369,7 +369,7 @@ macro_rules! impl_instant_for_integer {
         // Instant += Duration
         // We have limited this to use same numerator and denominator in both left and right hand sides,
         // this allows for the extension traits to work. For usage with different fraction, use
-        // `checked_add_duration`.
+        // [`Self::convert_add_duration`].
         impl<const NOM: u64, const DENOM: u64> ops::AddAssign<Duration<$i, NOM, DENOM>>
             for Instant<$i, NOM, DENOM>
         {
@@ -433,7 +433,7 @@ impl_instant_for_integer!(u64);
 // Instant - Duration = Instant
 // We have limited this to use same numerator and denominator in both left and right hand sides,
 // this allows for the extension traits to work. For usage with different fraction, use
-// `checked_sub_duration`.
+// [`Self::convert_sub_duration`].
 impl<const NOM: u64, const DENOM: u64> ops::Sub<Duration<u32, NOM, DENOM>>
     for Instant<u64, NOM, DENOM>
 {
@@ -442,7 +442,7 @@ impl<const NOM: u64, const DENOM: u64> ops::Sub<Duration<u32, NOM, DENOM>>
     #[inline]
     #[track_caller]
     fn sub(self, other: Duration<u32, NOM, DENOM>) -> Self::Output {
-        if let Some(v) = self.checked_sub_duration(other.into()) {
+        if let Some(v) = self.convert_sub_duration(other.into()) {
             v
         } else {
             panic!("Sub failed! Overflow");
@@ -453,7 +453,7 @@ impl<const NOM: u64, const DENOM: u64> ops::Sub<Duration<u32, NOM, DENOM>>
 // Instant -= Duration
 // We have limited this to use same numerator and denominator in both left and right hand sides,
 // this allows for the extension traits to work. For usage with different fraction, use
-// `checked_sub_duration`.
+// [`Self::convert_sub_duration`].
 impl<const NOM: u64, const DENOM: u64> ops::SubAssign<Duration<u32, NOM, DENOM>>
     for Instant<u64, NOM, DENOM>
 {
@@ -467,7 +467,7 @@ impl<const NOM: u64, const DENOM: u64> ops::SubAssign<Duration<u32, NOM, DENOM>>
 // Instant + Duration = Instant
 // We have limited this to use same numerator and denominator in both left and right hand sides,
 // this allows for the extension traits to work. For usage with different fraction, use
-// `checked_add_duration`.
+// [`Self::convert_add_duration`].
 impl<const NOM: u64, const DENOM: u64> ops::Add<Duration<u32, NOM, DENOM>>
     for Instant<u64, NOM, DENOM>
 {
@@ -476,7 +476,7 @@ impl<const NOM: u64, const DENOM: u64> ops::Add<Duration<u32, NOM, DENOM>>
     #[inline]
     #[track_caller]
     fn add(self, other: Duration<u32, NOM, DENOM>) -> Self::Output {
-        if let Some(v) = self.checked_add_duration(other.into()) {
+        if let Some(v) = self.convert_add_duration(other.into()) {
             v
         } else {
             panic!("Add failed! Overflow");
@@ -487,7 +487,7 @@ impl<const NOM: u64, const DENOM: u64> ops::Add<Duration<u32, NOM, DENOM>>
 // Instant += Duration
 // We have limited this to use same numerator and denominator in both left and right hand sides,
 // this allows for the extension traits to work. For usage with different fraction, use
-// `checked_add_duration`.
+// [`Self::convert_add_duration`].
 impl<const NOM: u64, const DENOM: u64> ops::AddAssign<Duration<u32, NOM, DENOM>>
     for Instant<u64, NOM, DENOM>
 {

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -86,8 +86,9 @@ macro_rules! impl_instant_for_integer {
                 }
             }
 
-            /// Duration between since the start of the `Instant`. This assumes an instant which
-            /// won't wrap within the execution of the program.
+            /// The duration between this instant and `Instant::from_ticks(0)`.
+            /// This duration is only valid if the `Instant` does not wrap during
+            /// the execution of the program.
             ///
             /// ```
             /// # use fugit::*;

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -131,11 +131,14 @@ macro_rules! impl_instant_for_integer {
                 }
             }
 
-            /// Subtract a `Duration` from an `Instant`.
+            /// Try to convert `other` into the `Self::NOM / Self::DENOM` timebase, and
+            /// subtract it from this [`Instant`].
             ///
-            /// The tick subtraction itself wraps (Instants are circular). Returns
-            /// `None` only when converting `other` into this Instant's base
-            /// overflows.
+            /// Returns `None` only if the time-base conversion fails. The subtraction itself
+            /// is wrapping, as [`Instant`]s are circular.
+            ///
+            /// The implementations of [`core::ops::Sub`] and [`core::ops::SubAssign`] are
+            /// implemented by `unwrap`-ing the value returned by this function.
             ///
             /// ```
             /// # use fugit::*;
@@ -143,6 +146,28 @@ macro_rules! impl_instant_for_integer {
             #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
             ///
             /// assert_eq!(i.checked_sub_duration(d).unwrap().as_ticks(), 0);
+            /// ```
+            ///
+            /// The subtraction itself is wrapping:
+            ///
+            /// ```
+            /// # use fugit::*;
+            #[doc = concat!("let i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 1_000>::from_ticks(2);")]
+            ///
+            #[doc = concat!("assert_eq!(i.checked_sub_duration(d).unwrap().as_ticks(), ", stringify!($i), "::MAX);")]
+            /// ```
+            ///
+            /// Overflow during [`Duration`] base conversion returns `None`:
+            ///
+            /// ```
+            /// # use fugit::*;
+            #[doc = concat!("let i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            /// // A duration whose conversion from the `1/500` base to the `1/1000` base
+            /// // will overflow.
+            #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 500>::from_ticks(", stringify!($i),"::MAX / 2 + 1);")]
+            ///
+            /// assert_eq!(i.checked_sub_duration(d), None);
             /// ```
             pub const fn checked_sub_duration<const O_NOM: u64, const O_DENOM: u64>(
                 self,
@@ -166,11 +191,14 @@ macro_rules! impl_instant_for_integer {
                 }
             }
 
-            /// Add a `Duration` to an `Instant`.
+            /// Try to convert `other` into the `Self::NOM / Self::DENOM` timebase, and
+            /// add it to this [`Instant`].
             ///
-            /// The tick addition itself wraps (Instants are circular). Returns
-            /// `None` only when converting `other` into this Instant's base
-            /// overflows.
+            /// Returns `None` only if the time-base conversion fails. The addition itself
+            /// is wrapping, as [`Instant`]s are circular.
+            ///
+            /// The implementations of [`core::ops::Add`] and [`core::ops::AddAssign`] are
+            /// implemented by `unwrap`-ing the value returned by this function.
             ///
             /// ```
             /// # use fugit::*;
@@ -178,6 +206,28 @@ macro_rules! impl_instant_for_integer {
             #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
             ///
             /// assert_eq!(i.checked_add_duration(d).unwrap().as_ticks(), 2);
+            /// ```
+            ///
+            /// The addition itself is wrapping:
+            ///
+            /// ```
+            /// # use fugit::*;
+            #[doc = concat!("let i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 1_000>::from_ticks(", stringify!($i), "::MAX);")]
+            ///
+            /// assert_eq!(i.checked_add_duration(d).unwrap().as_ticks(), 0);
+            /// ```
+            ///
+            /// Overflow during [`Duration`] base conversion returns `None`:
+            ///
+            /// ```
+            /// # use fugit::*;
+            #[doc = concat!("let i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            /// // A duration whose conversion from the `1/500` base to the `1/1000` base
+            /// // will overflow.
+            #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 500>::from_ticks(", stringify!($i),"::MAX / 2 + 1);")]
+            ///
+            /// assert_eq!(i.checked_add_duration(d), None);
             /// ```
             pub const fn checked_add_duration<const O_NOM: u64, const O_DENOM: u64>(
                 self,


### PR DESCRIPTION
The naming of `checked_{sub,add}_duration` can somewhat easily be interpreted as also checking the actual addition or subtraction as that is what the words imply in this order, but it is only checking the conversion. Rename them to (hopefully) reduce this ambiguity. This also aims to further improve the issues reported in #38. 

The old function names were also inconsistent with [`std::time::Instant::checked_{add,sub}`](https://doc.rust-lang.org/std/time/struct.Instant.html#method.checked_add) which _do_ check for overflow during the addition or subtraction.

Also add more examples to make it clear what they do.

There was also a stray `between  since` in `Instant::duration_since_epoch` which I fixed.

Am open to bikeshedding: other alternatives I was considering were `convert_{add,sub}_duration`, and `checked_convert_{sub_add}` (leaving out `Duration` since there are no other addition/subtraction implementations on `Instant`, so `Duration` is implied)

Alternatively, we could keep the names and just merge the updated docs with more examples.