### PR TITLE
Reject cross-base conversions whose constants don't fit the storage type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Issue #84: `Instant` comparison no longer reports `Equal` for instants that are not equal.
+- Cross-base operations on `u32` storage truncated their `u64` conversion constants, panicking with
+  a divide-by-zero or returning silently wrong results.
 
 ### Breaking Changes
 
+- **BREAKING**: Operations between time bases differing by more than the storage type's maximum are
+  now a compile-time error. Only `u32` storage with a base ratio above `u32::MAX` is affected.
 - **BREAKING**: Issue #83: `Instant` is no longer `Ord`, the wrapping compare is not transitive.
   `PartialOrd` is kept, so `<`, `>`, `<=` and `>=` are unaffected.
 - **BREAKING**: Issue #84: `Instant::const_cmp` is replaced by `const_partial_cmp`, which returns

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -1,4 +1,4 @@
-use crate::helpers::{div_round_nearest_u64, Helpers};
+use crate::helpers::{assert_conversion_fits, div_round_nearest_u64, Helpers};
 use crate::NanosDurationU64;
 use crate::Rate;
 use crate::SecsDurationU64;
@@ -10,6 +10,23 @@ use core::ops;
 ///
 /// The generic `T` can either be `u32` or `u64`, and the const generics represent the ratio of the
 /// ticks contained within the duration: `duration in seconds = NOM / DENOM * ticks`
+///
+/// # Base ratio limits
+///
+/// Operations between two different time bases convert through constants derived from the two
+/// ratios, and those constants have to fit the storage type `T`. Bases differing by more than
+/// `T::MAX` are rejected at compile time rather than silently truncating:
+///
+/// ```compile_fail
+/// # use fugit::*;
+/// let a = Duration::<u32, 1, 1>::from_ticks(1);
+/// // 1/2^32 s against 1 s exceeds what a u32 can express, so this does not build.
+/// let b = Duration::<u32, 1, 4_294_967_296>::from_ticks(1);
+/// let _ = a.checked_add(b);
+/// ```
+///
+/// The same pair is fine with `u64` storage, and the largest legal ratio for `u32` is
+/// `u32::MAX`.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(
     feature = "postcard_max_size",
@@ -192,6 +209,12 @@ macro_rules! impl_duration_for_integer {
                 self,
                 other: Duration<$i, O_NOM, O_DENOM>,
             ) -> Option<Self> {
+                assert_conversion_fits!(
+                    $i,
+                    Helpers::<NOM, DENOM, O_NOM, O_DENOM>,
+                    "Duration::checked_add"
+                );
+
                 if Helpers::<NOM, DENOM, O_NOM, O_DENOM>::SAME_BASE {
                     if let Some(ticks) = self.ticks.checked_add(other.ticks) {
                         Some(Self::from_ticks(ticks))
@@ -233,6 +256,12 @@ macro_rules! impl_duration_for_integer {
                 self,
                 other: Duration<$i, O_NOM, O_DENOM>,
             ) -> Option<Self> {
+                assert_conversion_fits!(
+                    $i,
+                    Helpers::<NOM, DENOM, O_NOM, O_DENOM>,
+                    "Duration::checked_sub"
+                );
+
                 if Helpers::<NOM, DENOM, O_NOM, O_DENOM>::SAME_BASE {
                     if let Some(ticks) = self.ticks.checked_sub(other.ticks) {
                         Some(Self::from_ticks(ticks))
@@ -308,6 +337,12 @@ macro_rules! impl_duration_for_integer {
                 self,
                 other: Duration<$i, O_NOM, O_DENOM>,
             ) -> Option<Self> {
+                assert_conversion_fits!(
+                    $i,
+                    Helpers::<NOM, DENOM, O_NOM, O_DENOM>,
+                    "Duration::checked_rem"
+                );
+
                 if other.ticks == 0 {
                     None
                 } else if Helpers::<NOM, DENOM, O_NOM, O_DENOM>::SAME_BASE {
@@ -454,6 +489,12 @@ macro_rules! impl_duration_for_integer {
                 // then perform the comparison in a comparable basis
                 //
 
+                assert_conversion_fits!(
+                    $i,
+                    Helpers::<NOM, DENOM, R_NOM, R_DENOM>,
+                    "Duration::const_partial_cmp"
+                );
+
                 if Helpers::<NOM, DENOM, R_NOM, R_DENOM>::SAME_BASE {
                     // If we are in the same base, comparison in trivial
                     Some(Self::_const_cmp(self.ticks, other.ticks))
@@ -490,6 +531,12 @@ macro_rules! impl_duration_for_integer {
                 self,
                 other: Duration<$i, R_NOM, R_DENOM>
             ) -> bool {
+                assert_conversion_fits!(
+                    $i,
+                    Helpers::<NOM, DENOM, R_NOM, R_DENOM>,
+                    "Duration::const_eq"
+                );
+
                 if Helpers::<NOM, DENOM, R_NOM, R_DENOM>::SAME_BASE {
                     // If we are in the same base, comparison in trivial
                     self.ticks == other.ticks

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -99,3 +99,39 @@ pub const fn div_round_nearest_u64(numerator: u64, divisor: u64) -> u64 {
         q
     }
 }
+
+// Compile-time assert that the cross-base conversion constants fit `$i`. Both are cast
+// `as $i` before use; a constant that fits `u64` but not the storage type would silently
+// truncate, and a divisor truncated to zero traps at runtime. This is the same check the
+// `Duration`/`Rate` shorthands already perform for their fixed bases, extended to the
+// conversions whose bases come from the caller.
+//
+// A same-base conversion reduces both constants to 1, so this never rejects one.
+macro_rules! assert_conversion_fits {
+    ($i:ty, $h:ty, $method:literal) => {
+        const {
+            assert!(
+                <$h>::LD_TIMES_RN <= <$i>::MAX as u64,
+                concat!(
+                    "LD_TIMES_RN doesn't fit in ",
+                    stringify!($i),
+                    " for ",
+                    $method,
+                    " between these time bases"
+                )
+            );
+            assert!(
+                <$h>::RD_TIMES_LN <= <$i>::MAX as u64,
+                concat!(
+                    "RD_TIMES_LN doesn't fit in ",
+                    stringify!($i),
+                    " for ",
+                    $method,
+                    " between these time bases"
+                )
+            );
+        }
+    };
+}
+
+pub(crate) use assert_conversion_fits;

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -1,5 +1,5 @@
 use crate::duration::Duration;
-use crate::helpers::Helpers;
+use crate::helpers::{assert_conversion_fits, Helpers};
 use core::cmp::Ordering;
 use core::ops;
 
@@ -7,6 +7,10 @@ use core::ops;
 ///
 /// The generic `T` can either be `u32` or `u64`, and the const generics represent the ratio of the
 /// ticks contained within the instant: `instant in seconds = NOM / DENOM * ticks`
+///
+/// Adding or subtracting a [`Duration`] in a different time base is subject to the same base
+/// ratio limits as [`Duration`] itself: bases differing by more than `T::MAX` are a compile-time
+/// error rather than a silent truncation.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(
     feature = "postcard_max_size",
@@ -184,6 +188,12 @@ macro_rules! impl_instant_for_integer {
                 self,
                 other: Duration<$i, O_NOM, O_DENOM>,
             ) -> Option<Self> {
+                assert_conversion_fits!(
+                    $i,
+                    Helpers::<NOM, DENOM, O_NOM, O_DENOM>,
+                    "Instant::convert_sub_duration"
+                );
+
                 if Helpers::<NOM, DENOM, O_NOM, O_DENOM>::SAME_BASE {
                     Some(Self::from_ticks(
                         self.ticks.wrapping_sub(other.as_ticks()),
@@ -244,6 +254,12 @@ macro_rules! impl_instant_for_integer {
                 self,
                 other: Duration<$i, O_NOM, O_DENOM>,
             ) -> Option<Self> {
+                assert_conversion_fits!(
+                    $i,
+                    Helpers::<NOM, DENOM, O_NOM, O_DENOM>,
+                    "Instant::convert_add_duration"
+                );
+
                 if Helpers::<NOM, DENOM, O_NOM, O_DENOM>::SAME_BASE {
                     Some(Self::from_ticks(
                         self.ticks.wrapping_add(other.as_ticks()),

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -1,4 +1,4 @@
-use crate::helpers::{div_round_nearest_u64, Helpers};
+use crate::helpers::{assert_conversion_fits, div_round_nearest_u64, Helpers};
 use crate::Duration;
 use core::cmp::Ordering;
 use core::convert;
@@ -8,6 +8,10 @@ use core::ops;
 ///
 /// The generic `T` can either be `u32` or `u64`, and the const generics represent the ratio of the
 /// raw contained within the rate: `rate in Hz = NOM / DENOM * raw`
+///
+/// Operations between two different bases are subject to the same base ratio limits as
+/// [`Duration`]: bases differing by more than `T::MAX` are a compile-time error rather than a
+/// silent truncation.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(
     feature = "postcard_max_size",
@@ -108,6 +112,12 @@ macro_rules! impl_rate_for_integer {
                 self,
                 other: Rate<$i, O_NOM, O_DENOM>,
             ) -> Option<Self> {
+                assert_conversion_fits!(
+                    $i,
+                    Helpers::<NOM, DENOM, O_NOM, O_DENOM>,
+                    "Rate::checked_add"
+                );
+
                 if Helpers::<NOM, DENOM, O_NOM, O_DENOM>::SAME_BASE {
                     if let Some(raw) = self.raw.checked_add(other.raw) {
                         Some(Self::from_raw(raw))
@@ -149,6 +159,12 @@ macro_rules! impl_rate_for_integer {
                 self,
                 other: Rate<$i, O_NOM, O_DENOM>,
             ) -> Option<Self> {
+                assert_conversion_fits!(
+                    $i,
+                    Helpers::<NOM, DENOM, O_NOM, O_DENOM>,
+                    "Rate::checked_sub"
+                );
+
                 if Helpers::<NOM, DENOM, O_NOM, O_DENOM>::SAME_BASE {
                     if let Some(raw) = self.raw.checked_sub(other.raw) {
                         Some(Self::from_raw(raw))
@@ -188,6 +204,12 @@ macro_rules! impl_rate_for_integer {
                 self,
                 other: Rate<$i, O_NOM, O_DENOM>,
             ) -> Option<Self> {
+                assert_conversion_fits!(
+                    $i,
+                    Helpers::<NOM, DENOM, O_NOM, O_DENOM>,
+                    "Rate::checked_rem"
+                );
+
                 if other.raw == 0 {
                     None
                 } else if Helpers::<NOM, DENOM, O_NOM, O_DENOM>::SAME_BASE {
@@ -239,6 +261,12 @@ macro_rules! impl_rate_for_integer {
                 self,
                 other: Rate<$i, R_NOM, R_DENOM>
             ) -> Option<Ordering> {
+                assert_conversion_fits!(
+                    $i,
+                    Helpers::<NOM, DENOM, R_NOM, R_DENOM>,
+                    "Rate::const_partial_cmp"
+                );
+
                 if Helpers::<NOM, DENOM, R_NOM, R_DENOM>::SAME_BASE {
                     // If we are in the same base, comparison in trivial
                     Some(Self::_const_cmp(self.raw, other.raw))
@@ -275,6 +303,12 @@ macro_rules! impl_rate_for_integer {
                 self,
                 other: Rate<$i, R_NOM, R_DENOM>
             ) -> bool {
+                assert_conversion_fits!(
+                    $i,
+                    Helpers::<NOM, DENOM, R_NOM, R_DENOM>,
+                    "Rate::const_eq"
+                );
+
                 if Helpers::<NOM, DENOM, R_NOM, R_DENOM>::SAME_BASE {
                     // If we are in the same base, comparison in trivial
                     self.raw == other.raw

--- a/src/test_duration.rs
+++ b/src/test_duration.rs
@@ -8,6 +8,42 @@ use crate::Instant;
 ////////////////////////////////////////////////////////////////////////////////
 
 #[test]
+fn duration_largest_fitting_conversion_constants_u32() {
+    // See `instant_largest_fitting_conversion_constants_u32`: a base ratio above the
+    // storage type is a compile-time error, so pin that the largest legal one works.
+    const MAX_RATIO: u64 = u32::MAX as u64;
+
+    let d = Duration::<u32, 1, 1>::from_ticks(1);
+    let one_second = Duration::<u32, 1, MAX_RATIO>::from_ticks(MAX_RATIO as u32);
+    let tiny = Duration::<u32, 1, MAX_RATIO>::from_ticks(1);
+
+    assert_eq!(
+        d.checked_add(one_second),
+        Some(Duration::<u32, 1, 1>::from_ticks(2))
+    );
+    assert_eq!(
+        d.checked_sub(one_second),
+        Some(Duration::<u32, 1, 1>::from_ticks(0))
+    );
+    assert_eq!(
+        d.checked_rem(one_second),
+        Some(Duration::<u32, 1, 1>::from_ticks(0))
+    );
+
+    // A sub-second operand converts to zero ticks, so a remainder by it is undefined.
+    assert_eq!(d.checked_rem(tiny), None);
+
+    // Comparison across the two bases has to respect the bases, not the raw ticks.
+    assert_eq!(
+        d.const_partial_cmp(tiny),
+        Some(core::cmp::Ordering::Greater)
+    );
+    assert!(d > tiny);
+    assert!(!d.const_eq(tiny));
+    assert!(d.const_eq(one_second));
+}
+
+#[test]
 fn large_duration_converstion() {
     use crate::ExtU64;
 

--- a/src/test_instant.rs
+++ b/src/test_instant.rs
@@ -230,6 +230,33 @@ fn instant_compare_is_not_transitive_u64() {
 }
 
 #[test]
+fn instant_largest_fitting_conversion_constants_u32() {
+    // The conversion constants are `u64` and get cast to the storage type, so bases whose
+    // ratio exceeds it are rejected at compile time. Right below that boundary the
+    // conversion must still work: a ratio of exactly `u32::MAX` is the largest legal one.
+    const MAX_RATIO: u64 = u32::MAX as u64;
+
+    let i = Instant::<u32, 1, 1>::from_ticks(1);
+    let d = Duration::<u32, 1, MAX_RATIO>::from_ticks(MAX_RATIO as u32);
+
+    // MAX_RATIO ticks of 1/MAX_RATIO s is exactly one second.
+    assert_eq!(
+        i.convert_add_duration(d),
+        Some(Instant::<u32, 1, 1>::from_ticks(2))
+    );
+    assert_eq!(
+        i.convert_sub_duration(d),
+        Some(Instant::<u32, 1, 1>::from_ticks(0))
+    );
+
+    // Sub-second remainders truncate toward zero rather than trapping.
+    assert_eq!(
+        i.convert_add_duration(Duration::<u32, 1, MAX_RATIO>::from_ticks(1)),
+        Some(Instant::<u32, 1, 1>::from_ticks(1))
+    );
+}
+
+#[test]
 fn instant_duration_math_u32() {
     use crate::ExtU32;
 

--- a/src/test_rate.rs
+++ b/src/test_rate.rs
@@ -5,6 +5,30 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 use crate::{Duration, Rate};
+
+#[test]
+fn rate_largest_fitting_conversion_constants_u32() {
+    // See `instant_largest_fitting_conversion_constants_u32`: a base ratio above the
+    // storage type is a compile-time error, so pin that the largest legal one works.
+    const MAX_RATIO: u64 = u32::MAX as u64;
+
+    let r = Rate::<u32, 1, 1>::from_raw(1);
+    let one = Rate::<u32, 1, MAX_RATIO>::from_raw(MAX_RATIO as u32);
+    let tiny = Rate::<u32, 1, MAX_RATIO>::from_raw(1);
+
+    assert_eq!(r.checked_add(one), Some(Rate::<u32, 1, 1>::from_raw(2)));
+    assert_eq!(r.checked_sub(one), Some(Rate::<u32, 1, 1>::from_raw(0)));
+    assert_eq!(r.checked_rem(tiny), None);
+
+    assert_eq!(
+        r.const_partial_cmp(tiny),
+        Some(core::cmp::Ordering::Greater)
+    );
+    assert!(r > tiny);
+    assert!(!r.const_eq(tiny));
+    assert!(r.const_eq(one));
+}
+
 use crate::{
     Hertz, HertzU32, HertzU64, Kilohertz, KilohertzU32, KilohertzU64, Megahertz, MegahertzU32,
     MegahertzU64, TimerRate, TimerRateU32, TimerRateU64,


### PR DESCRIPTION
The `u64` conversion constants were cast `as $i`, so on `u32` storage a constant of `2^32` truncated to `0` and the division trapped, while other values truncated silently and returned wrong results.

Assert at compile time that both fit, as the `Duration`/`Rate` shorthands already do for their fixed bases. Widening the math to `u64` instead would cost a libcall on every cross-base op to serve bases nobody instantiates.