### PR TITLE
Split `Instant` into monotonic and wrapping kinds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Run tests
         run: cargo test --all-features
 
+      - name: Run tests (release)
+        run: cargo test --all-features --release
+
       - name: Run doc tests
         run: cargo test --doc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- The `Monotonic` instant kind (together with the old `Wrapping` kind), for timelines that do not
+  wrap. Before, the `Instant` started to get methods that were related to `Monotonic` instants -
+  this is now split.
+- `MonotonicInstant`, `MonotonicTimerInstant`, `MonotonicTimerInstantU32` and
+  `MonotonicTimerInstantU64` aliases.
+- `Instant::is_before` and `Instant::is_after`, wrap-aware on `Wrapping`, a plain tick compare on
+  `Monotonic`.
+- `Instant` now implements `Hash`.
+- `Instant`'s `Debug` output names the kind: `WrappingInstant { ticks: 7 }`.
+
 ### Fixed
 
 - Issue #84: `Instant` comparison no longer reports `Equal` for instants that are not equal.
@@ -17,11 +29,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - **BREAKING**: Operations between time bases differing by more than the storage type's maximum are
   now a compile-time error. Only `u32` storage with a base ratio above `u32::MAX` is affected.
-- **BREAKING**: Issue #83: `Instant` is no longer `Ord`, the wrapping compare is not transitive.
-  `PartialOrd` is kept, so `<`, `>`, `<=` and `>=` are unaffected.
-- **BREAKING**: Issue #84: `Instant::const_cmp` is replaced by `const_partial_cmp`, which returns
-  `None` for instants exactly half the tick range apart.
-- **BREAKING**: Rename `checked_sub_duration` to `convert_sub_duration` and `checked_add_duration` to `convert_add_duration` with improved docs.
+- **BREAKING**: Issue #83: wrapping instants are no longer `Ord`, that compare is not transitive.
+  `PartialOrd` is kept, so `<`, `>`, `<=` and `>=` are unaffected. Monotonic instants are `Ord`.
+- **BREAKING**: Issue #84: on wrapping instants `const_cmp` is replaced by `const_partial_cmp`,
+  which returns `None` for instants exactly half the tick range apart. Monotonic instants keep
+  `const_cmp`, where a total order makes it sound.
+- **BREAKING**: Rename `checked_sub_duration` to `convert_sub_duration` and `checked_add_duration`
+  to `convert_add_duration` with improved docs.
+- **BREAKING**: `Instant` takes a fourth type parameter naming its timeline kind.
+  `Instant<u32, 1, 1_000>` becomes `WrappingInstant<u32, 1, 1_000>`, or `Instant<u32, 1, 1_000, kind::Wrapping>`.
+- **BREAKING**: The `TimerInstant`, `TimerInstantU32` and `TimerInstantU64` aliases are replaced by
+  `WrappingTimerInstant`, `WrappingTimerInstantU32` and `WrappingTimerInstantU64`.
+- **BREAKING**: `duration_since_epoch` is removed from wrapping instants, where a fixed epoch is
+  meaningless. Use `Duration::from_ticks(i.as_ticks())` for the old ticks-to-`Duration` shorthand.
 
 ## [v0.4.0] - 2026-05-06
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,34 @@ Extension traits provide convenient shorthand methods. Instead of manually creat
 
 Conversion to and from `core::time::Duration` is also provided, so values can cross the boundary between `fugit` and the standard library without manual reconstruction.
 
+## Two kinds of instant
+
+`Instant` names the kind of timeline it sits on, because a raw counter and an extended one need different operations to be correct. `WrappingInstant` wraps and compares wrap-aware, which is only meaningful within half the tick range, and it only implements `PartialOrd`. `MonotonicInstant` compares as a plain integer, and implements `Ord`.
+
+Nothing verifies that a monotonic timeline really does not wrap. `from_ticks` accepts any value, so feeding it a raw counter that has wrapped just produces an instant that is placed in the past. Use `WrappingInstant` for raw hardware counters and `MonotonicInstant` where the producer guarantees the monotonic timeline.
+
+### Migrating `Instant` from v0.4
+
+`Duration` and `Rate` gain no kind parameter.
+
+| v0.4                      | >=v0.5, wrapping                          | >=v0.5, monotonic                     |
+|---------------------------|-------------------------------------------|---------------------------------------|
+| `Instant<T, NOM, DENOM>`  | `WrappingInstant<T, NOM, DENOM>`          | `MonotonicInstant<T, NOM, DENOM>`     |
+| `TimerInstantU32<FREQ>`   | `WrappingTimerInstantU32<FREQ>`           | `MonotonicTimerInstantU32<FREQ>`      |
+| `TimerInstantU64<FREQ>`   | `WrappingTimerInstantU64<FREQ>`           | `MonotonicTimerInstantU64<FREQ>`      |
+| `checked_add_duration`    | `convert_add_duration`                    | same name, now checking the ticks too |
+| `checked_sub_duration`    | `convert_sub_duration`                    | same name, now checking the ticks too |
+| `const_cmp` -> `Ordering` | `const_partial_cmp` -> `Option<Ordering>` | unchanged                             |
+| `duration_since_epoch`    | `Duration::from_ticks(i.as_ticks())`      | unchanged                             |
+| `Ord`                     | removed                                   | unchanged                             |
+
+Watch the `checked_*_duration` rows: the name still compiles on a monotonic instant but now fails on tick overflow as well as on the base conversion.
+
+`Instant` with three generic arguments no longer names a type, so pick a kind or one of the aliases.
+
 ## Use Cases
 
-The library is particularly well-suited for embedded HAL implementations, RTIC applications, and any embedded system where you need to work with timeouts, delays, or periodic operations. The compile-time optimization means you get readable code without sacrificing the tight instruction counts needed on microcontrollers.
+The library is particularly well-suited for embedded HAL implementations, RTIC/embassy applications, and any embedded system where you need to work with timeouts, delays, or periodic operations. The compile-time optimization means you get readable code without sacrificing performance, especially on microcontrollers.
 
 ## License
 

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -1,5 +1,6 @@
 //! Type aliases for common uses
 
+use crate::kind::{Monotonic, Wrapping};
 use crate::Duration;
 use crate::Instant;
 use crate::Rate;
@@ -78,14 +79,35 @@ pub type TimerDurationU64<const FREQ_HZ: u64> = Duration<u64, 1, FREQ_HZ>;
 
 // -------------------------------
 
-/// Alias for instants that come from timers with a specific frequency
-pub type TimerInstant<T, const FREQ_HZ: u64> = Instant<T, 1, FREQ_HZ>;
+/// Alias for instants on a monotonic timeline
+pub type MonotonicInstant<T, const NOM: u64, const DENOM: u64> = Instant<T, NOM, DENOM, Monotonic>;
 
-/// Alias for instants that come from timers with a specific frequency (`u32` backing storage)
-pub type TimerInstantU32<const FREQ_HZ: u64> = Instant<u32, 1, FREQ_HZ>;
+/// Alias for monotonic instants that come from timers with a specific frequency
+pub type MonotonicTimerInstant<T, const FREQ_HZ: u64> = Instant<T, 1, FREQ_HZ, Monotonic>;
 
-/// Alias for instants that come from timers with a specific frequency (`u64` backing storage)
-pub type TimerInstantU64<const FREQ_HZ: u64> = Instant<u64, 1, FREQ_HZ>;
+/// Alias for monotonic instants that come from timers with a specific frequency (`u32` backing
+/// storage)
+pub type MonotonicTimerInstantU32<const FREQ_HZ: u64> = Instant<u32, 1, FREQ_HZ, Monotonic>;
+
+/// Alias for monotonic instants that come from timers with a specific frequency (`u64` backing
+/// storage)
+pub type MonotonicTimerInstantU64<const FREQ_HZ: u64> = Instant<u64, 1, FREQ_HZ, Monotonic>;
+
+// -------------------------------
+
+/// Alias for instants on a wrapping counter
+pub type WrappingInstant<T, const NOM: u64, const DENOM: u64> = Instant<T, NOM, DENOM, Wrapping>;
+
+/// Alias for wrapping instants that come from timers with a specific frequency
+pub type WrappingTimerInstant<T, const FREQ_HZ: u64> = Instant<T, 1, FREQ_HZ, Wrapping>;
+
+/// Alias for wrapping instants that come from timers with a specific frequency (`u32` backing
+/// storage)
+pub type WrappingTimerInstantU32<const FREQ_HZ: u64> = Instant<u32, 1, FREQ_HZ, Wrapping>;
+
+/// Alias for wrapping instants that come from timers with a specific frequency (`u64` backing
+/// storage)
+pub type WrappingTimerInstantU64<const FREQ_HZ: u64> = Instant<u64, 1, FREQ_HZ, Wrapping>;
 
 // -------------------------------
 

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -1,6 +1,8 @@
 use crate::duration::Duration;
 use crate::helpers::{assert_conversion_fits, Helpers};
+use crate::kind::{Kind, Monotonic, Wrapping};
 use core::cmp::Ordering;
+use core::marker::PhantomData;
 use core::ops;
 
 /// Represents an instant in time.
@@ -8,41 +10,64 @@ use core::ops;
 /// The generic `T` can either be `u32` or `u64`, and the const generics represent the ratio of the
 /// ticks contained within the instant: `instant in seconds = NOM / DENOM * ticks`
 ///
+/// `K` says how the timeline is read. See [`kind`](crate::kind), or use an alias such as
+/// [`WrappingInstant`](crate::WrappingInstant).
+///
 /// Adding or subtracting a [`Duration`] in a different time base is subject to the same base
 /// ratio limits as [`Duration`] itself: bases differing by more than `T::MAX` are a compile-time
 /// error rather than a silent truncation.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(
-    feature = "postcard_max_size",
-    derive(postcard::experimental::max_size::MaxSize)
-)]
-#[derive(Clone, Copy, Debug)]
-pub struct Instant<T, const NOM: u64, const DENOM: u64> {
+#[derive(Clone, Copy, Hash, PartialEq, Eq)]
+pub struct Instant<T, const NOM: u64, const DENOM: u64, K> {
     ticks: T,
+    #[cfg_attr(feature = "serde", serde(skip))]
+    _kind: PhantomData<K>,
 }
 
-macro_rules! impl_instant_for_integer {
+#[cfg(feature = "postcard_max_size")]
+impl<T: postcard::experimental::max_size::MaxSize, const NOM: u64, const DENOM: u64, K>
+    postcard::experimental::max_size::MaxSize for Instant<T, NOM, DENOM, K>
+{
+    const POSTCARD_MAX_SIZE: usize = T::POSTCARD_MAX_SIZE;
+}
+
+impl<T: core::fmt::Debug, const NOM: u64, const DENOM: u64, K: Kind> core::fmt::Debug
+    for Instant<T, NOM, DENOM, K>
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct(K::DEBUG_NAME)
+            .field("ticks", &self.ticks)
+            .finish()
+    }
+}
+
+/// Construction, equality and formatting: everything whose behaviour does not depend on how
+/// the instant's timeline is read.
+macro_rules! impl_instant_shared {
     ($i:ty) => {
-        impl<const NOM: u64, const DENOM: u64> Instant<$i, NOM, DENOM> {
+        impl<const NOM: u64, const DENOM: u64, K: Kind> Instant<$i, NOM, DENOM, K> {
             /// Create an `Instant` from a ticks value.
             ///
             /// ```
             /// # use fugit::*;
-            #[doc = concat!("let _i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("let _i = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
             /// ```
             #[inline]
             pub const fn from_ticks(ticks: $i) -> Self {
                 const { assert!(NOM > 0) };
                 const { assert!(DENOM > 0) };
 
-                Instant { ticks }
+                Instant {
+                    ticks,
+                    _kind: PhantomData,
+                }
             }
 
             /// Extract the ticks from an `Instant`.
             ///
             /// ```
             /// # use fugit::*;
-            #[doc = concat!("let i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(234);")]
+            #[doc = concat!("let i = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(234);")]
             ///
             /// assert_eq!(i.as_ticks(), 234);
             /// ```
@@ -50,13 +75,68 @@ macro_rules! impl_instant_for_integer {
             pub const fn as_ticks(&self) -> $i {
                 self.ticks
             }
+        }
 
+        #[cfg(feature = "defmt")]
+        impl<const NOM: u64, const DENOM: u64, K: Kind> defmt::Format for Instant<$i, NOM, DENOM, K> {
+            fn format(&self, f: defmt::Formatter) {
+                if NOM == 3_600 && DENOM == 1 {
+                    defmt::write!(f, "{} h", self.ticks)
+                } else if NOM == 60 && DENOM == 1 {
+                    defmt::write!(f, "{} min", self.ticks)
+                } else if NOM == 1 && DENOM == 1 {
+                    defmt::write!(f, "{} s", self.ticks)
+                } else if NOM == 1 && DENOM == 1_000 {
+                    defmt::write!(f, "{} ms", self.ticks)
+                } else if NOM == 1 && DENOM == 1_000_000 {
+                    defmt::write!(f, "{} us", self.ticks)
+                } else if NOM == 1 && DENOM == 1_000_000_000 {
+                    defmt::write!(f, "{} ns", self.ticks)
+                } else if NOM == 1 && DENOM == 1_000_000_000_000 {
+                    defmt::write!(f, "{} ps", self.ticks)
+                } else {
+                    defmt::write!(f, "{} ticks @ ({}/{})", self.ticks, NOM, DENOM)
+                }
+            }
+        }
+
+        impl<const NOM: u64, const DENOM: u64, K: Kind> core::fmt::Display
+            for Instant<$i, NOM, DENOM, K>
+        {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                if NOM == 3_600 && DENOM == 1 {
+                    write!(f, "{} h", self.ticks)
+                } else if NOM == 60 && DENOM == 1 {
+                    write!(f, "{} min", self.ticks)
+                } else if NOM == 1 && DENOM == 1 {
+                    write!(f, "{} s", self.ticks)
+                } else if NOM == 1 && DENOM == 1_000 {
+                    write!(f, "{} ms", self.ticks)
+                } else if NOM == 1 && DENOM == 1_000_000 {
+                    write!(f, "{} us", self.ticks)
+                } else if NOM == 1 && DENOM == 1_000_000_000 {
+                    write!(f, "{} ns", self.ticks)
+                } else if NOM == 1 && DENOM == 1_000_000_000_000 {
+                    write!(f, "{} ps", self.ticks)
+                } else {
+                    write!(f, "{} ticks @ ({}/{})", self.ticks, NOM, DENOM)
+                }
+            }
+        }
+    };
+}
+
+/// Comparison and arithmetic for instants read as a circular counter: ticks wrap, and the
+/// ordering is wrap-aware and therefore only partial.
+macro_rules! impl_instant_wrapping {
+    ($i:ty) => {
+        impl<const NOM: u64, const DENOM: u64> Instant<$i, NOM, DENOM, Wrapping> {
             /// Const partial comparison of `Instant`s.
             ///
             /// ```
             /// # use fugit::*;
-            #[doc = concat!("let i1 = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
-            #[doc = concat!("let i2 = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(2);")]
+            #[doc = concat!("let i1 = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("let i2 = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(2);")]
             ///
             /// assert_eq!(i1.const_partial_cmp(i2), Some(core::cmp::Ordering::Less));
             /// ```
@@ -67,8 +147,8 @@ macro_rules! impl_instant_for_integer {
             ///
             /// ```
             /// # use fugit::*;
-            #[doc = concat!("let i1 = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(", stringify!($i),"::MAX);")]
-            #[doc = concat!("let i2 = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("let i1 = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(", stringify!($i),"::MAX);")]
+            #[doc = concat!("let i2 = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
             ///
             /// assert_eq!(i1.const_partial_cmp(i2), Some(core::cmp::Ordering::Less));
             /// ```
@@ -79,8 +159,8 @@ macro_rules! impl_instant_for_integer {
             ///
             /// ```
             /// # use fugit::*;
-            #[doc = concat!("let i1 = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(0);")]
-            #[doc = concat!("let i2 = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1 << (", stringify!($i), "::BITS - 1));")]
+            #[doc = concat!("let i1 = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(0);")]
+            #[doc = concat!("let i2 = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1 << (", stringify!($i), "::BITS - 1));")]
             ///
             /// assert_eq!(i1.const_partial_cmp(i2), None);
             /// ```
@@ -102,19 +182,46 @@ macro_rules! impl_instant_for_integer {
                 }
             }
 
-            /// The duration between this instant and `Instant::from_ticks(0)`.
-            /// This duration is only valid if the `Instant` does not wrap during
-            /// the execution of the program.
+            /// Whether this `Instant` comes before `other`.
+            ///
+            /// Wrap-aware, like [`const_partial_cmp`](Self::const_partial_cmp), and usable in
+            /// const contexts where `<` is not. Instants exactly half the tick range apart are
+            /// incomparable, so this and [`is_after`](Self::is_after) are both `false` for them.
             ///
             /// ```
             /// # use fugit::*;
-            #[doc = concat!("let i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(11);")]
+            #[doc = concat!("const I1: WrappingInstant<", stringify!($i), ", 1, 1_000>")]
+            #[doc = concat!("    = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(", stringify!($i), "::MAX);")]
+            #[doc = concat!("const I2: WrappingInstant<", stringify!($i), ", 1, 1_000>")]
+            #[doc = concat!("    = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            /// const BEFORE: bool = I1.is_before(I2);
             ///
-            /// assert_eq!(i.duration_since_epoch().as_ticks(), 11);
+            /// assert!(BEFORE);
             /// ```
             #[inline]
-            pub const fn duration_since_epoch(self) -> Duration<$i, NOM, DENOM> {
-                Duration::<$i, NOM, DENOM>::from_ticks(self.as_ticks())
+            pub const fn is_before(self, other: Self) -> bool {
+                matches!(self.const_partial_cmp(other), Some(Ordering::Less))
+            }
+
+            /// Whether this `Instant` comes after `other`.
+            ///
+            /// Wrap-aware, like [`const_partial_cmp`](Self::const_partial_cmp), and usable in
+            /// const contexts where `>` is not. Instants exactly half the tick range apart are
+            /// incomparable, so this and [`is_before`](Self::is_before) are both `false` for them.
+            ///
+            /// ```
+            /// # use fugit::*;
+            #[doc = concat!("const I1: WrappingInstant<", stringify!($i), ", 1, 1_000>")]
+            #[doc = concat!("    = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("const I2: WrappingInstant<", stringify!($i), ", 1, 1_000>")]
+            #[doc = concat!("    = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(", stringify!($i), "::MAX);")]
+            /// const AFTER: bool = I1.is_after(I2);
+            ///
+            /// assert!(AFTER);
+            /// ```
+            #[inline]
+            pub const fn is_after(self, other: Self) -> bool {
+                matches!(self.const_partial_cmp(other), Some(Ordering::Greater))
             }
 
             /// Duration between `Instant`s.
@@ -125,8 +232,8 @@ macro_rules! impl_instant_for_integer {
             ///
             /// ```
             /// # use fugit::*;
-            #[doc = concat!("let i1 = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
-            #[doc = concat!("let i2 = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(2);")]
+            #[doc = concat!("let i1 = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("let i2 = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(2);")]
             ///
             /// assert_eq!(i1.checked_duration_since(i2), None);
             /// assert_eq!(i2.checked_duration_since(i1).unwrap().as_ticks(), 1);
@@ -157,7 +264,7 @@ macro_rules! impl_instant_for_integer {
             ///
             /// ```
             /// # use fugit::*;
-            #[doc = concat!("let i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("let i = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
             #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
             ///
             /// assert_eq!(i.convert_sub_duration(d).unwrap().as_ticks(), 0);
@@ -167,7 +274,7 @@ macro_rules! impl_instant_for_integer {
             ///
             /// ```
             /// # use fugit::*;
-            #[doc = concat!("let i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("let i = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
             #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 1_000>::from_ticks(2);")]
             ///
             #[doc = concat!("assert_eq!(i.convert_sub_duration(d).unwrap().as_ticks(), ", stringify!($i), "::MAX);")]
@@ -177,7 +284,7 @@ macro_rules! impl_instant_for_integer {
             ///
             /// ```
             /// # use fugit::*;
-            #[doc = concat!("let i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("let i = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
             /// // A duration whose conversion from the `1/500` base to the `1/1000` base
             /// // will overflow.
             #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 500>::from_ticks(", stringify!($i),"::MAX / 2 + 1);")]
@@ -223,7 +330,7 @@ macro_rules! impl_instant_for_integer {
             ///
             /// ```
             /// # use fugit::*;
-            #[doc = concat!("let i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("let i = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
             #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
             ///
             /// assert_eq!(i.convert_add_duration(d).unwrap().as_ticks(), 2);
@@ -233,7 +340,7 @@ macro_rules! impl_instant_for_integer {
             ///
             /// ```
             /// # use fugit::*;
-            #[doc = concat!("let i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("let i = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
             #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 1_000>::from_ticks(", stringify!($i), "::MAX);")]
             ///
             /// assert_eq!(i.convert_add_duration(d).unwrap().as_ticks(), 0);
@@ -243,7 +350,7 @@ macro_rules! impl_instant_for_integer {
             ///
             /// ```
             /// # use fugit::*;
-            #[doc = concat!("let i = Instant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("let i = WrappingInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
             /// // A duration whose conversion from the `1/500` base to the `1/1000` base
             /// // will overflow.
             #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 500>::from_ticks(", stringify!($i),"::MAX / 2 + 1);")]
@@ -279,7 +386,7 @@ macro_rules! impl_instant_for_integer {
             }
         }
 
-        impl<const NOM: u64, const DENOM: u64> PartialOrd for Instant<$i, NOM, DENOM> {
+        impl<const NOM: u64, const DENOM: u64> PartialOrd for Instant<$i, NOM, DENOM, Wrapping> {
             /// This implementation deviates from the definition of
             /// [PartialOrd::partial_cmp](core::cmp::PartialOrd::partial_cmp):
             ///
@@ -287,7 +394,9 @@ macro_rules! impl_instant_for_integer {
             /// values of `self` and `other` differ by more than half the possible range, it is
             /// assumed that an overflow occured and the result is reversed.
             ///
-            /// That breaks the transitivity invariant: a < b and b < c no longer implies a < c.
+            /// That breaks the transitivity invariant: a < b and b < c no longer implies a < c,
+            /// which is formally more than [`PartialOrd`] permits. The impl is kept as a
+            /// conscious exception so `<` and `>` remain usable, see [`Wrapping`](crate::kind::Wrapping).
             /// [`Ord`](core::cmp::Ord) is for that reason deliberately not implemented, as its
             /// users - `BTreeMap`, `sort`, `max` - need a transitive total order and silently
             /// misbehave without one.
@@ -300,41 +409,12 @@ macro_rules! impl_instant_for_integer {
             }
         }
 
-        impl<const NOM: u64, const DENOM: u64> PartialEq for Instant<$i, NOM, DENOM> {
-            #[inline]
-            fn eq(&self, other: &Self) -> bool {
-                self.ticks.eq(&other.ticks)
-            }
-        }
-
-        impl<const NOM: u64, const DENOM: u64> Eq for Instant<$i, NOM, DENOM> {}
-
-        // Instant - Instant = Duration
-        // We have limited this to use same numerator and denominator in both left and right hand sides,
-        // this allows for the extension traits to work. For usage with different fraction, use
-        // `checked_duration_since`.
-        impl<const NOM: u64, const DENOM: u64> ops::Sub<Instant<$i, NOM, DENOM>>
-            for Instant<$i, NOM, DENOM>
-        {
-            type Output = Duration<$i, NOM, DENOM>;
-
-            #[inline]
-            #[track_caller]
-            fn sub(self, other: Self) -> Self::Output {
-                if let Some(v) = self.checked_duration_since(other) {
-                    v
-                } else {
-                    panic!("Sub failed! Other > self");
-                }
-            }
-        }
-
         // Instant - Duration = Instant
         // We have limited this to use same numerator and denominator in both left and right hand sides,
         // this allows for the extension traits to work. For usage with different fraction, use
         // [`Self::convert_sub_duration`].
         impl<const NOM: u64, const DENOM: u64> ops::Sub<Duration<$i, NOM, DENOM>>
-            for Instant<$i, NOM, DENOM>
+            for Instant<$i, NOM, DENOM, Wrapping>
         {
             type Output = Self;
 
@@ -349,26 +429,12 @@ macro_rules! impl_instant_for_integer {
             }
         }
 
-        // Instant -= Duration
-        // We have limited this to use same numerator and denominator in both left and right hand sides,
-        // this allows for the extension traits to work. For usage with different fraction, use
-        // [`Self::convert_sub_duration`].
-        impl<const NOM: u64, const DENOM: u64> ops::SubAssign<Duration<$i, NOM, DENOM>>
-            for Instant<$i, NOM, DENOM>
-        {
-            #[inline]
-            #[track_caller]
-            fn sub_assign(&mut self, other: Duration<$i, NOM, DENOM>) {
-                *self = *self - other;
-            }
-        }
-
         // Instant + Duration = Instant
         // We have limited this to use same numerator and denominator in both left and right hand sides,
         // this allows for the extension traits to work. For usage with different fraction, use
         // [`Self::convert_add_duration`].
         impl<const NOM: u64, const DENOM: u64> ops::Add<Duration<$i, NOM, DENOM>>
-            for Instant<$i, NOM, DENOM>
+            for Instant<$i, NOM, DENOM, Wrapping>
         {
             type Output = Self;
 
@@ -382,136 +448,344 @@ macro_rules! impl_instant_for_integer {
                 }
             }
         }
+    };
+}
 
-        // Instant += Duration
-        // We have limited this to use same numerator and denominator in both left and right hand sides,
-        // this allows for the extension traits to work. For usage with different fraction, use
-        // [`Self::convert_add_duration`].
-        impl<const NOM: u64, const DENOM: u64> ops::AddAssign<Duration<$i, NOM, DENOM>>
-            for Instant<$i, NOM, DENOM>
-        {
+/// Comparison and arithmetic for instants on a timeline that does not wrap: tick math is plain
+/// integer math, and the ordering is total.
+macro_rules! impl_instant_monotonic {
+    ($i:ty) => {
+        impl<const NOM: u64, const DENOM: u64> Instant<$i, NOM, DENOM, Monotonic> {
+            /// Const comparison of `Instant`s.
+            ///
+            /// ```
+            /// # use fugit::*;
+            #[doc = concat!("let i1 = MonotonicInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("let i2 = MonotonicInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(2);")]
+            ///
+            /// assert_eq!(i1.const_cmp(i2), core::cmp::Ordering::Less);
+            /// ```
             #[inline]
-            #[track_caller]
-            fn add_assign(&mut self, other: Duration<$i, NOM, DENOM>) {
-                *self = *self + other;
-            }
-        }
-
-        #[cfg(feature = "defmt")]
-        impl<const NOM: u64, const DENOM: u64> defmt::Format for Instant<$i, NOM, DENOM> {
-            fn format(&self, f: defmt::Formatter) {
-                if NOM == 3_600 && DENOM == 1 {
-                    defmt::write!(f, "{} h", self.ticks)
-                } else if NOM == 60 && DENOM == 1 {
-                    defmt::write!(f, "{} min", self.ticks)
-                } else if NOM == 1 && DENOM == 1 {
-                    defmt::write!(f, "{} s", self.ticks)
-                } else if NOM == 1 && DENOM == 1_000 {
-                    defmt::write!(f, "{} ms", self.ticks)
-                } else if NOM == 1 && DENOM == 1_000_000 {
-                    defmt::write!(f, "{} us", self.ticks)
-                } else if NOM == 1 && DENOM == 1_000_000_000 {
-                    defmt::write!(f, "{} ns", self.ticks)
+            pub const fn const_cmp(self, other: Self) -> Ordering {
+                // not using `cmp` due to it being non-const
+                if self.ticks < other.ticks {
+                    Ordering::Less
+                } else if self.ticks > other.ticks {
+                    Ordering::Greater
                 } else {
-                    defmt::write!(f, "{} ticks @ ({}/{})", self.ticks, NOM, DENOM)
+                    Ordering::Equal
+                }
+            }
+
+            /// Whether this `Instant` comes before `other`.
+            ///
+            /// Usable in const contexts, where `<` is not.
+            ///
+            /// ```
+            /// # use fugit::*;
+            #[doc = concat!("const I1: MonotonicInstant<", stringify!($i), ", 1, 1_000>")]
+            #[doc = concat!("    = MonotonicInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("const I2: MonotonicInstant<", stringify!($i), ", 1, 1_000>")]
+            #[doc = concat!("    = MonotonicInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(2);")]
+            /// const BEFORE: bool = I1.is_before(I2);
+            ///
+            /// assert!(BEFORE);
+            /// ```
+            #[inline]
+            pub const fn is_before(self, other: Self) -> bool {
+                self.ticks < other.ticks
+            }
+
+            /// Whether this `Instant` comes after `other`.
+            ///
+            /// Usable in const contexts, where `>` is not.
+            ///
+            /// ```
+            /// # use fugit::*;
+            #[doc = concat!("const I1: MonotonicInstant<", stringify!($i), ", 1, 1_000>")]
+            #[doc = concat!("    = MonotonicInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(2);")]
+            #[doc = concat!("const I2: MonotonicInstant<", stringify!($i), ", 1, 1_000>")]
+            #[doc = concat!("    = MonotonicInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            /// const AFTER: bool = I1.is_after(I2);
+            ///
+            /// assert!(AFTER);
+            /// ```
+            #[inline]
+            pub const fn is_after(self, other: Self) -> bool {
+                self.ticks > other.ticks
+            }
+
+            /// The duration between this instant and `Instant::from_ticks(0)`.
+            ///
+            /// ```
+            /// # use fugit::*;
+            #[doc = concat!("let i = MonotonicInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(11);")]
+            ///
+            /// assert_eq!(i.duration_since_epoch().as_ticks(), 11);
+            /// ```
+            #[inline]
+            pub const fn duration_since_epoch(self) -> Duration<$i, NOM, DENOM> {
+                Duration::<$i, NOM, DENOM>::from_ticks(self.as_ticks())
+            }
+
+            /// Duration between `Instant`s.
+            ///
+            /// Returns `None` if `self` is before `other`.
+            ///
+            /// ```
+            /// # use fugit::*;
+            #[doc = concat!("let i1 = MonotonicInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("let i2 = MonotonicInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(2);")]
+            ///
+            /// assert_eq!(i1.checked_duration_since(i2), None);
+            /// assert_eq!(i2.checked_duration_since(i1).unwrap().as_ticks(), 1);
+            /// ```
+            #[inline]
+            pub const fn checked_duration_since(
+                self,
+                other: Self,
+            ) -> Option<Duration<$i, NOM, DENOM>> {
+                match self.ticks.checked_sub(other.ticks) {
+                    Some(ticks) => Some(Duration::<$i, NOM, DENOM>::from_ticks(ticks)),
+                    None => None,
+                }
+            }
+
+            /// Try to convert `other` into the `Self::NOM / Self::DENOM` timebase, and
+            /// subtract it from this [`Instant`].
+            ///
+            /// Returns `None` if the time-base conversion fails, or if the subtraction would go
+            /// below zero. Note that those two causes are not distinguished.
+            ///
+            /// ```
+            /// # use fugit::*;
+            #[doc = concat!("let i = MonotonicInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            ///
+            /// assert_eq!(i.checked_sub_duration(d).unwrap().as_ticks(), 0);
+            /// ```
+            ///
+            /// Going below zero returns `None` rather than wrapping:
+            ///
+            /// ```
+            /// # use fugit::*;
+            #[doc = concat!("let i = MonotonicInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 1_000>::from_ticks(2);")]
+            ///
+            /// assert_eq!(i.checked_sub_duration(d), None);
+            /// ```
+            pub const fn checked_sub_duration<const O_NOM: u64, const O_DENOM: u64>(
+                self,
+                other: Duration<$i, O_NOM, O_DENOM>,
+            ) -> Option<Self> {
+                assert_conversion_fits!(
+                    $i,
+                    Helpers::<NOM, DENOM, O_NOM, O_DENOM>,
+                    "Instant::checked_sub_duration"
+                );
+
+                match Duration::<$i, NOM, DENOM>::from_ticks(self.ticks).checked_sub(other) {
+                    Some(d) => Some(Self::from_ticks(d.as_ticks())),
+                    None => None,
+                }
+            }
+
+            /// Try to convert `other` into the `Self::NOM / Self::DENOM` timebase, and
+            /// add it to this [`Instant`].
+            ///
+            /// Returns `None` if the time-base conversion fails, or if the addition would
+            /// overflow the storage type. Note that those two causes are not distinguished.
+            ///
+            /// ```
+            /// # use fugit::*;
+            #[doc = concat!("let i = MonotonicInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            ///
+            /// assert_eq!(i.checked_add_duration(d).unwrap().as_ticks(), 2);
+            /// ```
+            ///
+            /// Overflowing the storage type returns `None` rather than wrapping:
+            ///
+            /// ```
+            /// # use fugit::*;
+            #[doc = concat!("let i = MonotonicInstant::<", stringify!($i), ", 1, 1_000>::from_ticks(1);")]
+            #[doc = concat!("let d = Duration::<", stringify!($i), ", 1, 1_000>::from_ticks(", stringify!($i), "::MAX);")]
+            ///
+            /// assert_eq!(i.checked_add_duration(d), None);
+            /// ```
+            pub const fn checked_add_duration<const O_NOM: u64, const O_DENOM: u64>(
+                self,
+                other: Duration<$i, O_NOM, O_DENOM>,
+            ) -> Option<Self> {
+                assert_conversion_fits!(
+                    $i,
+                    Helpers::<NOM, DENOM, O_NOM, O_DENOM>,
+                    "Instant::checked_add_duration"
+                );
+
+                match Duration::<$i, NOM, DENOM>::from_ticks(self.ticks).checked_add(other) {
+                    Some(d) => Some(Self::from_ticks(d.as_ticks())),
+                    None => None,
                 }
             }
         }
 
-        impl<const NOM: u64, const DENOM: u64> core::fmt::Display for Instant<$i, NOM, DENOM> {
-            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                if NOM == 3_600 && DENOM == 1 {
-                    write!(f, "{} h", self.ticks)
-                } else if NOM == 60 && DENOM == 1 {
-                    write!(f, "{} min", self.ticks)
-                } else if NOM == 1 && DENOM == 1 {
-                    write!(f, "{} s", self.ticks)
-                } else if NOM == 1 && DENOM == 1_000 {
-                    write!(f, "{} ms", self.ticks)
-                } else if NOM == 1 && DENOM == 1_000_000 {
-                    write!(f, "{} us", self.ticks)
-                } else if NOM == 1 && DENOM == 1_000_000_000 {
-                    write!(f, "{} ns", self.ticks)
+        impl<const NOM: u64, const DENOM: u64> Ord for Instant<$i, NOM, DENOM, Monotonic> {
+            #[inline]
+            fn cmp(&self, other: &Self) -> Ordering {
+                self.ticks.cmp(&other.ticks)
+            }
+        }
+
+        impl<const NOM: u64, const DENOM: u64> PartialOrd for Instant<$i, NOM, DENOM, Monotonic> {
+            #[inline]
+            fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+
+        // Instant - Duration = Instant
+        // We have limited this to use same numerator and denominator in both left and right hand sides,
+        // this allows for the extension traits to work. For usage with different fraction, use
+        // [`Self::checked_sub_duration`].
+        //
+        // Plain `-`, so this inherits `overflow-checks` from the final binary: a panic in debug and
+        // a wrap in release, exactly like the underlying integer.
+        impl<const NOM: u64, const DENOM: u64> ops::Sub<Duration<$i, NOM, DENOM>>
+            for Instant<$i, NOM, DENOM, Monotonic>
+        {
+            type Output = Self;
+
+            #[inline]
+            #[track_caller]
+            fn sub(self, other: Duration<$i, NOM, DENOM>) -> Self::Output {
+                Self::from_ticks(self.ticks - other.as_ticks())
+            }
+        }
+
+        // Instant + Duration = Instant
+        // We have limited this to use same numerator and denominator in both left and right hand sides,
+        // this allows for the extension traits to work. For usage with different fraction, use
+        // [`Self::checked_add_duration`].
+        //
+        // Plain `+`, see the `Sub` impl above.
+        impl<const NOM: u64, const DENOM: u64> ops::Add<Duration<$i, NOM, DENOM>>
+            for Instant<$i, NOM, DENOM, Monotonic>
+        {
+            type Output = Self;
+
+            #[inline]
+            #[track_caller]
+            fn add(self, other: Duration<$i, NOM, DENOM>) -> Self::Output {
+                Self::from_ticks(self.ticks + other.as_ticks())
+            }
+        }
+    };
+}
+
+/// `Instant - Instant = Duration`, the one operator body both kinds share.
+macro_rules! impl_instant_ops {
+    ($i:ty, $k:ty) => {
+        // Instant - Instant = Duration
+        // We have limited this to use same numerator and denominator in both left and right hand sides,
+        // this allows for the extension traits to work. For usage with different fraction, use
+        // `checked_duration_since`.
+        impl<const NOM: u64, const DENOM: u64> ops::Sub<Instant<$i, NOM, DENOM, $k>>
+            for Instant<$i, NOM, DENOM, $k>
+        {
+            type Output = Duration<$i, NOM, DENOM>;
+
+            #[inline]
+            #[track_caller]
+            fn sub(self, other: Self) -> Self::Output {
+                if let Some(v) = self.checked_duration_since(other) {
+                    v
                 } else {
-                    write!(f, "{} ticks @ ({}/{})", self.ticks, NOM, DENOM)
+                    panic!("Sub failed! Other is not before self");
                 }
             }
         }
     };
 }
 
-impl_instant_for_integer!(u32);
-impl_instant_for_integer!(u64);
+impl_instant_shared!(u32);
+impl_instant_shared!(u64);
+
+impl_instant_wrapping!(u32);
+impl_instant_wrapping!(u64);
+
+impl_instant_monotonic!(u32);
+impl_instant_monotonic!(u64);
+
+impl_instant_ops!(u32, Wrapping);
+impl_instant_ops!(u64, Wrapping);
+impl_instant_ops!(u32, Monotonic);
+impl_instant_ops!(u64, Monotonic);
+
+// Instant -= Duration and Instant += Duration, for every duration the instant can `Sub`/`Add`,
+// resolving through the kind's own operator.
+impl<T, D, const NOM: u64, const DENOM: u64, K> ops::SubAssign<D> for Instant<T, NOM, DENOM, K>
+where
+    Self: Copy + ops::Sub<D, Output = Self>,
+{
+    #[inline]
+    #[track_caller]
+    fn sub_assign(&mut self, other: D) {
+        *self = *self - other;
+    }
+}
+
+impl<T, D, const NOM: u64, const DENOM: u64, K> ops::AddAssign<D> for Instant<T, NOM, DENOM, K>
+where
+    Self: Copy + ops::Add<D, Output = Self>,
+{
+    #[inline]
+    #[track_caller]
+    fn add_assign(&mut self, other: D) {
+        *self = *self + other;
+    }
+}
 
 //
-// Operations between u32 Duration and u64 Instant
+// Operations between a `u64` `Instant` and a `u32` `Duration`.
+//
+// These need no macro. They widen the `Duration` and defer to the same-base operator rather than
+// naming a conversion method, and the widening is exact, so the bodies hold for any timeline.
 //
 
 // Instant - Duration = Instant
 // We have limited this to use same numerator and denominator in both left and right hand sides,
-// this allows for the extension traits to work. For usage with different fraction, use
-// [`Self::convert_sub_duration`].
-impl<const NOM: u64, const DENOM: u64> ops::Sub<Duration<u32, NOM, DENOM>>
-    for Instant<u64, NOM, DENOM>
+// this allows for the extension traits to work. For usage with different fraction, use the
+// kind's `convert_sub_duration`/`checked_sub_duration`.
+impl<const NOM: u64, const DENOM: u64, K: Kind> ops::Sub<Duration<u32, NOM, DENOM>>
+    for Instant<u64, NOM, DENOM, K>
+where
+    Instant<u64, NOM, DENOM, K>: ops::Sub<Duration<u64, NOM, DENOM>, Output = Self>,
 {
     type Output = Self;
 
     #[inline]
     #[track_caller]
     fn sub(self, other: Duration<u32, NOM, DENOM>) -> Self::Output {
-        if let Some(v) = self.convert_sub_duration(other.into()) {
-            v
-        } else {
-            panic!("Sub failed! Overflow");
-        }
-    }
-}
-
-// Instant -= Duration
-// We have limited this to use same numerator and denominator in both left and right hand sides,
-// this allows for the extension traits to work. For usage with different fraction, use
-// [`Self::convert_sub_duration`].
-impl<const NOM: u64, const DENOM: u64> ops::SubAssign<Duration<u32, NOM, DENOM>>
-    for Instant<u64, NOM, DENOM>
-{
-    #[inline]
-    #[track_caller]
-    fn sub_assign(&mut self, other: Duration<u32, NOM, DENOM>) {
-        *self = *self - other;
+        self - Duration::<u64, NOM, DENOM>::from(other)
     }
 }
 
 // Instant + Duration = Instant
 // We have limited this to use same numerator and denominator in both left and right hand sides,
-// this allows for the extension traits to work. For usage with different fraction, use
-// [`Self::convert_add_duration`].
-impl<const NOM: u64, const DENOM: u64> ops::Add<Duration<u32, NOM, DENOM>>
-    for Instant<u64, NOM, DENOM>
+// this allows for the extension traits to work. For usage with different fraction, use the
+// kind's `convert_add_duration`/`checked_add_duration`.
+impl<const NOM: u64, const DENOM: u64, K: Kind> ops::Add<Duration<u32, NOM, DENOM>>
+    for Instant<u64, NOM, DENOM, K>
+where
+    Instant<u64, NOM, DENOM, K>: ops::Add<Duration<u64, NOM, DENOM>, Output = Self>,
 {
     type Output = Self;
 
     #[inline]
     #[track_caller]
     fn add(self, other: Duration<u32, NOM, DENOM>) -> Self::Output {
-        if let Some(v) = self.convert_add_duration(other.into()) {
-            v
-        } else {
-            panic!("Add failed! Overflow");
-        }
-    }
-}
-
-// Instant += Duration
-// We have limited this to use same numerator and denominator in both left and right hand sides,
-// this allows for the extension traits to work. For usage with different fraction, use
-// [`Self::convert_add_duration`].
-impl<const NOM: u64, const DENOM: u64> ops::AddAssign<Duration<u32, NOM, DENOM>>
-    for Instant<u64, NOM, DENOM>
-{
-    #[inline]
-    #[track_caller]
-    fn add_assign(&mut self, other: Duration<u32, NOM, DENOM>) {
-        *self = *self + other;
+        self + Duration::<u64, NOM, DENOM>::from(other)
     }
 }
 

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -1,0 +1,48 @@
+//! Markers that say how an [`Instant`](crate::Instant)'s timeline is read.
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// The set of timelines an [`Instant`](crate::Instant) can be on.
+///
+/// Sealed: the kinds are [`Monotonic`] and [`Wrapping`].
+pub trait Kind: Copy + sealed::Sealed {
+    /// The name shown for instants of this kind in `Debug` output.
+    const DEBUG_NAME: &'static str;
+}
+
+/// Marker for an instant on a timeline that does not wrap.
+///
+/// Total order, so [`Ord`]. Arithmetic is plain `+` and `-`, panicking on overflow in debug and
+/// wrapping in release. Nothing checks that the timeline really does not wrap, so use
+/// [`Wrapping`] for raw hardware counters.
+#[derive(Copy, Clone, Hash, PartialEq, Eq)]
+pub enum Monotonic {}
+
+impl sealed::Sealed for Monotonic {}
+impl Kind for Monotonic {
+    const DEBUG_NAME: &'static str = "MonotonicInstant";
+}
+
+/// Marker for an instant on a circular counter, such as a hardware timer.
+///
+/// Arithmetic wraps, and comparison reads `self - other` as a signed offset, so it is only
+/// meaningful within half the tick range and not transitive. [`PartialOrd`] formally requires
+/// transitivity too; implementing it anyway is a conscious decision to keep `<` and `>` usable,
+/// and the ordering holds whenever the compared instants lie within half the tick range of each
+/// other. [`Ord`] is not implemented:
+///
+/// ```compile_fail
+/// use fugit::WrappingInstant;
+///
+/// fn assert_ord<T: Ord>() {}
+/// assert_ord::<WrappingInstant<u32, 1, 1_000>>();
+/// ```
+#[derive(Copy, Clone, Hash, PartialEq, Eq)]
+pub enum Wrapping {}
+
+impl sealed::Sealed for Wrapping {}
+impl Kind for Wrapping {
+    const DEBUG_NAME: &'static str = "WrappingInstant";
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,25 @@
 //!     //                (Cortex-M3+) to perform the comparison.
 //! }
 //! ```
+//!
+//! # Two kinds of instant
+//!
+//! [`Instant`] takes a [`kind`] as its last type parameter, because the two
+//! readings of a timestamp need different operations to be correct.
+//!
+//! Pick [`Wrapping`](kind::Wrapping) for a raw hardware counter. Ticks wrap, and comparison is
+//! wrap-aware, which is only meaningful within half the tick range and is not transitive, so
+//! there is no [`Ord`].
+//!
+//! Pick [`Monotonic`](kind::Monotonic) for a timeline that does not wrap, such as a counter
+//! extended to 64 bits in software. Comparison is a plain integer compare, so it is [`Ord`].
+//!
+//! Nothing checks the claim that a monotonic timeline does not wrap: [`Instant::from_ticks`]
+//! takes any value, so a counter that wrapped before the value arrived is invisible here and
+//! [`Ord`] will simply place the instant in the past. The producer owns that guarantee.
+//!
+//! Use the aliases rather than naming a marker: [`WrappingTimerInstantU32`],
+//! [`MonotonicTimerInstantU64`] and friends.
 
 #![cfg_attr(not(test), no_std)]
 #![deny(missing_docs)]
@@ -48,6 +67,7 @@ mod aliases;
 mod duration;
 mod helpers;
 mod instant;
+pub mod kind;
 mod rate;
 
 pub use aliases::*;

--- a/src/test_duration.rs
+++ b/src/test_duration.rs
@@ -1,5 +1,5 @@
 use crate::Duration;
-use crate::Instant;
+use crate::WrappingInstant;
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -91,35 +91,43 @@ fn duration_compare_u32() {
 
     // From instants
     assert!(
-        Instant::<u32, 1, 1_000>::from_ticks(10) - Instant::<u32, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u32, 1, 1_000>::from_ticks(5)
             > Duration::<u32, 1, 1_000>::from_ticks(4)
     );
     assert!(
-        Instant::<u32, 1, 1_000>::from_ticks(10) - Instant::<u32, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u32, 1, 1_000>::from_ticks(5)
             >= Duration::<u32, 1, 1_000>::from_ticks(4)
     );
     assert!(
-        Instant::<u32, 1, 1_000>::from_ticks(10) - Instant::<u32, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u32, 1, 1_000>::from_ticks(5)
             >= Duration::<u32, 1, 1_000>::from_ticks(5)
     );
     assert!(
-        Instant::<u32, 1, 1_000>::from_ticks(10) - Instant::<u32, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u32, 1, 1_000>::from_ticks(5)
             < Duration::<u32, 1, 1_000>::from_ticks(6)
     );
     assert!(
-        Instant::<u32, 1, 1_000>::from_ticks(10) - Instant::<u32, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u32, 1, 1_000>::from_ticks(5)
             <= Duration::<u32, 1, 1_000>::from_ticks(6)
     );
     assert!(
-        Instant::<u32, 1, 1_000>::from_ticks(10) - Instant::<u32, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u32, 1, 1_000>::from_ticks(5)
             <= Duration::<u32, 1, 1_000>::from_ticks(5)
     );
     assert!(
-        Instant::<u32, 1, 1_000>::from_ticks(10) - Instant::<u32, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u32, 1, 1_000>::from_ticks(5)
             == Duration::<u32, 1, 1_000>::from_ticks(5)
     );
     assert!(
-        Instant::<u32, 1, 1_000>::from_ticks(10) - Instant::<u32, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u32, 1, 1_000>::from_ticks(5)
             != Duration::<u32, 1, 1_000>::from_ticks(4)
     );
 }
@@ -148,35 +156,43 @@ fn duration_compare_u64() {
 
     // From instants
     assert!(
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Instant::<u64, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u64, 1, 1_000>::from_ticks(5)
             > Duration::<u64, 1, 1_000>::from_ticks(4)
     );
     assert!(
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Instant::<u64, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u64, 1, 1_000>::from_ticks(5)
             >= Duration::<u64, 1, 1_000>::from_ticks(4)
     );
     assert!(
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Instant::<u64, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u64, 1, 1_000>::from_ticks(5)
             >= Duration::<u64, 1, 1_000>::from_ticks(5)
     );
     assert!(
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Instant::<u64, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u64, 1, 1_000>::from_ticks(5)
             < Duration::<u64, 1, 1_000>::from_ticks(6)
     );
     assert!(
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Instant::<u64, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u64, 1, 1_000>::from_ticks(5)
             <= Duration::<u64, 1, 1_000>::from_ticks(6)
     );
     assert!(
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Instant::<u64, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u64, 1, 1_000>::from_ticks(5)
             <= Duration::<u64, 1, 1_000>::from_ticks(5)
     );
     assert!(
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Instant::<u64, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u64, 1, 1_000>::from_ticks(5)
             == Duration::<u64, 1, 1_000>::from_ticks(5)
     );
     assert!(
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Instant::<u64, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u64, 1, 1_000>::from_ticks(5)
             != Duration::<u64, 1, 1_000>::from_ticks(4)
     );
 }
@@ -205,35 +221,43 @@ fn duration_compare_u64_u32() {
 
     // From instants
     assert!(
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Instant::<u64, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u64, 1, 1_000>::from_ticks(5)
             > Duration::<u32, 1, 1_000>::from_ticks(4)
     );
     assert!(
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Instant::<u64, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u64, 1, 1_000>::from_ticks(5)
             >= Duration::<u32, 1, 1_000>::from_ticks(4)
     );
     assert!(
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Instant::<u64, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u64, 1, 1_000>::from_ticks(5)
             >= Duration::<u32, 1, 1_000>::from_ticks(5)
     );
     assert!(
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Instant::<u64, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u64, 1, 1_000>::from_ticks(5)
             < Duration::<u32, 1, 1_000>::from_ticks(6)
     );
     assert!(
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Instant::<u64, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u64, 1, 1_000>::from_ticks(5)
             <= Duration::<u32, 1, 1_000>::from_ticks(6)
     );
     assert!(
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Instant::<u64, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u64, 1, 1_000>::from_ticks(5)
             <= Duration::<u32, 1, 1_000>::from_ticks(5)
     );
     assert!(
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Instant::<u64, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u64, 1, 1_000>::from_ticks(5)
             == Duration::<u32, 1, 1_000>::from_ticks(5)
     );
     assert!(
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Instant::<u64, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u64, 1, 1_000>::from_ticks(5)
             != Duration::<u32, 1, 1_000>::from_ticks(4)
     );
 }
@@ -262,35 +286,43 @@ fn duration_compare_u32_u64() {
 
     // From instants
     assert!(
-        Instant::<u32, 1, 1_000>::from_ticks(10) - Instant::<u32, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u32, 1, 1_000>::from_ticks(5)
             > Duration::<u64, 1, 1_000>::from_ticks(4)
     );
     assert!(
-        Instant::<u32, 1, 1_000>::from_ticks(10) - Instant::<u32, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u32, 1, 1_000>::from_ticks(5)
             >= Duration::<u64, 1, 1_000>::from_ticks(4)
     );
     assert!(
-        Instant::<u32, 1, 1_000>::from_ticks(10) - Instant::<u32, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u32, 1, 1_000>::from_ticks(5)
             >= Duration::<u64, 1, 1_000>::from_ticks(5)
     );
     assert!(
-        Instant::<u32, 1, 1_000>::from_ticks(10) - Instant::<u32, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u32, 1, 1_000>::from_ticks(5)
             < Duration::<u64, 1, 1_000>::from_ticks(6)
     );
     assert!(
-        Instant::<u32, 1, 1_000>::from_ticks(10) - Instant::<u32, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u32, 1, 1_000>::from_ticks(5)
             <= Duration::<u64, 1, 1_000>::from_ticks(6)
     );
     assert!(
-        Instant::<u32, 1, 1_000>::from_ticks(10) - Instant::<u32, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u32, 1, 1_000>::from_ticks(5)
             <= Duration::<u64, 1, 1_000>::from_ticks(5)
     );
     assert!(
-        Instant::<u32, 1, 1_000>::from_ticks(10) - Instant::<u32, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u32, 1, 1_000>::from_ticks(5)
             == Duration::<u64, 1, 1_000>::from_ticks(5)
     );
     assert!(
-        Instant::<u32, 1, 1_000>::from_ticks(10) - Instant::<u32, 1, 1_000>::from_ticks(5)
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(10)
+            - WrappingInstant::<u32, 1, 1_000>::from_ticks(5)
             != Duration::<u64, 1, 1_000>::from_ticks(4)
     );
 }

--- a/src/test_instant.rs
+++ b/src/test_instant.rs
@@ -4,55 +4,79 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-use crate::{Duration, Instant};
+use crate::{Duration, MonotonicInstant, WrappingInstant};
 
 #[test]
 fn instant_compare_u32() {
     // Wrapping
     assert!(
-        Instant::<u32, 1, 1_000>::from_ticks(1) > Instant::<u32, 1, 1_000>::from_ticks(u32::MAX)
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(1)
+            > WrappingInstant::<u32, 1, 1_000>::from_ticks(u32::MAX)
     );
     assert!(
-        Instant::<u32, 1, 1_000>::from_ticks(u32::MAX - 1)
-            < Instant::<u32, 1, 1_000>::from_ticks(u32::MAX)
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(u32::MAX - 1)
+            < WrappingInstant::<u32, 1, 1_000>::from_ticks(u32::MAX)
     );
 
     // Non-wrapping
-    assert!(Instant::<u32, 1, 1_000>::from_ticks(2) > Instant::<u32, 1, 1_000>::from_ticks(1));
-    assert!(Instant::<u32, 1, 1_000>::from_ticks(2) >= Instant::<u32, 1, 1_000>::from_ticks(1));
-    assert!(Instant::<u32, 1, 1_000>::from_ticks(1) >= Instant::<u32, 1, 1_000>::from_ticks(1));
-    assert!(Instant::<u32, 1, 1_000>::from_ticks(1) < Instant::<u32, 1, 1_000>::from_ticks(2));
-    assert!(Instant::<u32, 1, 1_000>::from_ticks(1) <= Instant::<u32, 1, 1_000>::from_ticks(1));
-    assert!(Instant::<u32, 1, 1_000>::from_ticks(1) <= Instant::<u32, 1, 1_000>::from_ticks(2));
-    assert!(Instant::<u32, 1, 1_000>::from_ticks(1) == Instant::<u32, 1, 1_000>::from_ticks(1));
-    assert!(Instant::<u32, 1, 1_000>::from_ticks(1) != Instant::<u32, 1, 1_000>::from_ticks(2));
+    assert!(
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(2)
+            > WrappingInstant::<u32, 1, 1_000>::from_ticks(1)
+    );
+    assert!(
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(2)
+            >= WrappingInstant::<u32, 1, 1_000>::from_ticks(1)
+    );
+    assert!(
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(1)
+            >= WrappingInstant::<u32, 1, 1_000>::from_ticks(1)
+    );
+    assert!(
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(1)
+            < WrappingInstant::<u32, 1, 1_000>::from_ticks(2)
+    );
+    assert!(
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(1)
+            <= WrappingInstant::<u32, 1, 1_000>::from_ticks(1)
+    );
+    assert!(
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(1)
+            <= WrappingInstant::<u32, 1, 1_000>::from_ticks(2)
+    );
+    assert!(
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(1)
+            == WrappingInstant::<u32, 1, 1_000>::from_ticks(1)
+    );
+    assert!(
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(1)
+            != WrappingInstant::<u32, 1, 1_000>::from_ticks(2)
+    );
 
     // Checked duration since non-wrapping
+    let one = WrappingInstant::<u32, 1, 1_000>::from_ticks(1);
+    let two = WrappingInstant::<u32, 1, 1_000>::from_ticks(2);
+    let three = WrappingInstant::<u32, 1, 1_000>::from_ticks(3);
+
     assert_eq!(
-        Instant::<u32, 1, 1_000>::from_ticks(1)
-            .checked_duration_since(Instant::<u32, 1, 1_000>::from_ticks(1)),
+        one.checked_duration_since(one),
         Some(Duration::<u32, 1, 1_000>::from_ticks(0))
     );
     assert_eq!(
-        Instant::<u32, 1, 1_000>::from_ticks(2)
-            .checked_duration_since(Instant::<u32, 1, 1_000>::from_ticks(1)),
+        two.checked_duration_since(one),
         Some(Duration::<u32, 1, 1_000>::from_ticks(1))
     );
-    assert_eq!(
-        Instant::<u32, 1, 1_000>::from_ticks(2)
-            .checked_duration_since(Instant::<u32, 1, 1_000>::from_ticks(3)),
-        None
-    );
+    assert_eq!(two.checked_duration_since(three), None);
 
     // Checked duration since wrapping
+    let max = WrappingInstant::<u32, 1, 1_000>::from_ticks(u32::MAX);
+    let max_minus_one = WrappingInstant::<u32, 1, 1_000>::from_ticks(u32::MAX - 1);
+
     assert_eq!(
-        Instant::<u32, 1, 1_000>::from_ticks(2)
-            .checked_duration_since(Instant::<u32, 1, 1_000>::from_ticks(u32::MAX)),
+        two.checked_duration_since(max),
         Some(Duration::<u32, 1, 1_000>::from_ticks(3))
     );
     assert_eq!(
-        Instant::<u32, 1, 1_000>::from_ticks(2)
-            .checked_duration_since(Instant::<u32, 1, 1_000>::from_ticks(u32::MAX - 1)),
+        two.checked_duration_since(max_minus_one),
         Some(Duration::<u32, 1, 1_000>::from_ticks(4))
     );
 }
@@ -61,49 +85,73 @@ fn instant_compare_u32() {
 fn instant_compare_u64() {
     // Wrapping
     assert!(
-        Instant::<u64, 1, 1_000>::from_ticks(1) > Instant::<u64, 1, 1_000>::from_ticks(u64::MAX)
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(1)
+            > WrappingInstant::<u64, 1, 1_000>::from_ticks(u64::MAX)
     );
     assert!(
-        Instant::<u64, 1, 1_000>::from_ticks(u64::MAX - 1)
-            < Instant::<u64, 1, 1_000>::from_ticks(u64::MAX)
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(u64::MAX - 1)
+            < WrappingInstant::<u64, 1, 1_000>::from_ticks(u64::MAX)
     );
 
     // Non-wrapping
-    assert!(Instant::<u64, 1, 1_000>::from_ticks(2) > Instant::<u64, 1, 1_000>::from_ticks(1));
-    assert!(Instant::<u64, 1, 1_000>::from_ticks(2) >= Instant::<u64, 1, 1_000>::from_ticks(1));
-    assert!(Instant::<u64, 1, 1_000>::from_ticks(1) >= Instant::<u64, 1, 1_000>::from_ticks(1));
-    assert!(Instant::<u64, 1, 1_000>::from_ticks(1) < Instant::<u64, 1, 1_000>::from_ticks(2));
-    assert!(Instant::<u64, 1, 1_000>::from_ticks(1) <= Instant::<u64, 1, 1_000>::from_ticks(1));
-    assert!(Instant::<u64, 1, 1_000>::from_ticks(1) <= Instant::<u64, 1, 1_000>::from_ticks(2));
-    assert!(Instant::<u64, 1, 1_000>::from_ticks(1) == Instant::<u64, 1, 1_000>::from_ticks(1));
-    assert!(Instant::<u64, 1, 1_000>::from_ticks(1) != Instant::<u64, 1, 1_000>::from_ticks(2));
+    assert!(
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(2)
+            > WrappingInstant::<u64, 1, 1_000>::from_ticks(1)
+    );
+    assert!(
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(2)
+            >= WrappingInstant::<u64, 1, 1_000>::from_ticks(1)
+    );
+    assert!(
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(1)
+            >= WrappingInstant::<u64, 1, 1_000>::from_ticks(1)
+    );
+    assert!(
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(1)
+            < WrappingInstant::<u64, 1, 1_000>::from_ticks(2)
+    );
+    assert!(
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(1)
+            <= WrappingInstant::<u64, 1, 1_000>::from_ticks(1)
+    );
+    assert!(
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(1)
+            <= WrappingInstant::<u64, 1, 1_000>::from_ticks(2)
+    );
+    assert!(
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(1)
+            == WrappingInstant::<u64, 1, 1_000>::from_ticks(1)
+    );
+    assert!(
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(1)
+            != WrappingInstant::<u64, 1, 1_000>::from_ticks(2)
+    );
 
     // Checked duration since non-wrapping
+    let one = WrappingInstant::<u64, 1, 1_000>::from_ticks(1);
+    let two = WrappingInstant::<u64, 1, 1_000>::from_ticks(2);
+    let three = WrappingInstant::<u64, 1, 1_000>::from_ticks(3);
+
     assert_eq!(
-        Instant::<u64, 1, 1_000>::from_ticks(1)
-            .checked_duration_since(Instant::<u64, 1, 1_000>::from_ticks(1)),
+        one.checked_duration_since(one),
         Some(Duration::<u64, 1, 1_000>::from_ticks(0))
     );
     assert_eq!(
-        Instant::<u64, 1, 1_000>::from_ticks(2)
-            .checked_duration_since(Instant::<u64, 1, 1_000>::from_ticks(1)),
+        two.checked_duration_since(one),
         Some(Duration::<u64, 1, 1_000>::from_ticks(1))
     );
-    assert_eq!(
-        Instant::<u64, 1, 1_000>::from_ticks(2)
-            .checked_duration_since(Instant::<u64, 1, 1_000>::from_ticks(3)),
-        None
-    );
+    assert_eq!(two.checked_duration_since(three), None);
 
     // Checked duration since wrapping
+    let max = WrappingInstant::<u64, 1, 1_000>::from_ticks(u64::MAX);
+    let max_minus_one = WrappingInstant::<u64, 1, 1_000>::from_ticks(u64::MAX - 1);
+
     assert_eq!(
-        Instant::<u64, 1, 1_000>::from_ticks(2)
-            .checked_duration_since(Instant::<u64, 1, 1_000>::from_ticks(u64::MAX)),
+        two.checked_duration_since(max),
         Some(Duration::<u64, 1, 1_000>::from_ticks(3))
     );
     assert_eq!(
-        Instant::<u64, 1, 1_000>::from_ticks(2)
-            .checked_duration_since(Instant::<u64, 1, 1_000>::from_ticks(u64::MAX - 1)),
+        two.checked_duration_since(max_minus_one),
         Some(Duration::<u64, 1, 1_000>::from_ticks(4))
     );
 }
@@ -113,33 +161,46 @@ fn instant_compare_half_range_u32() {
     use core::cmp::Ordering;
 
     const HALF: u32 = 1 << 31;
-    let i = Instant::<u32, 1, 1_000>::from_ticks;
+
+    let zero = WrappingInstant::<u32, 1, 1_000>::from_ticks(0);
+    let one = WrappingInstant::<u32, 1, 1_000>::from_ticks(1);
+    let half = WrappingInstant::<u32, 1, 1_000>::from_ticks(HALF);
+    let half_plus_one = WrappingInstant::<u32, 1, 1_000>::from_ticks(HALF + 1);
+    let one_plus_half = WrappingInstant::<u32, 1, 1_000>::from_ticks(1 + HALF);
 
     // The largest unambiguous difference. Used to report `Equal` while the ticks differ.
-    assert_eq!(i(HALF).const_partial_cmp(i(1)), Some(Ordering::Greater));
-    assert_eq!(i(1).const_partial_cmp(i(HALF)), Some(Ordering::Less));
-    assert!(i(HALF) != i(1));
+    assert_eq!(half.const_partial_cmp(one), Some(Ordering::Greater));
+    assert_eq!(one.const_partial_cmp(half), Some(Ordering::Less));
+    assert!(half != one);
 
-    // Exactly half the range apart: `a - b` and `b - a` are both `HALF`, so neither
+    // Exactly half the range apart: the difference is `HALF` in both directions, so neither
     // comes first and no comparison holds.
-    let (a, b) = (i(1), i(1 + HALF));
-    assert_eq!(a.const_partial_cmp(b), None);
-    assert_eq!(b.const_partial_cmp(a), None);
-    for holds in [a < b, a > b, a <= b, a >= b, a == b] {
+    assert_eq!(one.const_partial_cmp(one_plus_half), None);
+    assert_eq!(one_plus_half.const_partial_cmp(one), None);
+    for holds in [
+        one < one_plus_half,
+        one > one_plus_half,
+        one <= one_plus_half,
+        one >= one_plus_half,
+        one == one_plus_half,
+    ] {
         assert!(!holds);
     }
 
     // Just past half the range, the comparison flips.
-    assert_eq!(i(HALF + 1).const_partial_cmp(i(0)), Some(Ordering::Less));
-    assert_eq!(i(0).const_partial_cmp(i(HALF + 1)), Some(Ordering::Greater));
+    assert_eq!(half_plus_one.const_partial_cmp(zero), Some(Ordering::Less));
+    assert_eq!(
+        zero.const_partial_cmp(half_plus_one),
+        Some(Ordering::Greater)
+    );
 
     // `checked_duration_since` is unaffected by the fix.
     assert_eq!(
-        i(HALF).checked_duration_since(i(1)),
+        half.checked_duration_since(one),
         Some(Duration::<u32, 1, 1_000>::from_ticks(HALF - 1))
     );
-    assert_eq!(a.checked_duration_since(b), None);
-    assert_eq!(b.checked_duration_since(a), None);
+    assert_eq!(one.checked_duration_since(one_plus_half), None);
+    assert_eq!(one_plus_half.checked_duration_since(one), None);
 }
 
 #[test]
@@ -147,28 +208,41 @@ fn instant_compare_half_range_u64() {
     use core::cmp::Ordering;
 
     const HALF: u64 = 1 << 63;
-    let i = Instant::<u64, 1, 1_000>::from_ticks;
 
-    assert_eq!(i(HALF).const_partial_cmp(i(1)), Some(Ordering::Greater));
-    assert_eq!(i(1).const_partial_cmp(i(HALF)), Some(Ordering::Less));
-    assert!(i(HALF) != i(1));
+    let zero = WrappingInstant::<u64, 1, 1_000>::from_ticks(0);
+    let one = WrappingInstant::<u64, 1, 1_000>::from_ticks(1);
+    let half = WrappingInstant::<u64, 1, 1_000>::from_ticks(HALF);
+    let half_plus_one = WrappingInstant::<u64, 1, 1_000>::from_ticks(HALF + 1);
+    let one_plus_half = WrappingInstant::<u64, 1, 1_000>::from_ticks(1 + HALF);
 
-    let (a, b) = (i(1), i(1 + HALF));
-    assert_eq!(a.const_partial_cmp(b), None);
-    assert_eq!(b.const_partial_cmp(a), None);
-    for holds in [a < b, a > b, a <= b, a >= b, a == b] {
+    assert_eq!(half.const_partial_cmp(one), Some(Ordering::Greater));
+    assert_eq!(one.const_partial_cmp(half), Some(Ordering::Less));
+    assert!(half != one);
+
+    assert_eq!(one.const_partial_cmp(one_plus_half), None);
+    assert_eq!(one_plus_half.const_partial_cmp(one), None);
+    for holds in [
+        one < one_plus_half,
+        one > one_plus_half,
+        one <= one_plus_half,
+        one >= one_plus_half,
+        one == one_plus_half,
+    ] {
         assert!(!holds);
     }
 
-    assert_eq!(i(HALF + 1).const_partial_cmp(i(0)), Some(Ordering::Less));
-    assert_eq!(i(0).const_partial_cmp(i(HALF + 1)), Some(Ordering::Greater));
+    assert_eq!(half_plus_one.const_partial_cmp(zero), Some(Ordering::Less));
+    assert_eq!(
+        zero.const_partial_cmp(half_plus_one),
+        Some(Ordering::Greater)
+    );
 
     assert_eq!(
-        i(HALF).checked_duration_since(i(1)),
+        half.checked_duration_since(one),
         Some(Duration::<u64, 1, 1_000>::from_ticks(HALF - 1))
     );
-    assert_eq!(a.checked_duration_since(b), None);
-    assert_eq!(b.checked_duration_since(a), None);
+    assert_eq!(one.checked_duration_since(one_plus_half), None);
+    assert_eq!(one_plus_half.checked_duration_since(one), None);
 }
 
 #[test]
@@ -189,8 +263,8 @@ fn instant_compare_duality_u32() {
         u32::MAX - 1,
         u32::MAX,
     ] {
-        let a = Instant::<u32, 1, 1_000>::from_ticks(base);
-        let b = Instant::<u32, 1, 1_000>::from_ticks(base.wrapping_add(offset));
+        let a = WrappingInstant::<u32, 1, 1_000>::from_ticks(base);
+        let b = WrappingInstant::<u32, 1, 1_000>::from_ticks(base.wrapping_add(offset));
 
         assert_eq!(
             a.const_partial_cmp(b).map(Ordering::reverse),
@@ -209,9 +283,9 @@ fn instant_compare_duality_u32() {
 fn instant_compare_is_not_transitive_u32() {
     // The wrapping compare is not transitive, which is why `Instant` is deliberately not
     // `Ord`: `BTreeMap`, `sort` and friends silently misbehave on such an ordering.
-    let a = Instant::<u32, 1, 1_000>::from_ticks(0);
-    let b = Instant::<u32, 1, 1_000>::from_ticks(0x6000_0000);
-    let c = Instant::<u32, 1, 1_000>::from_ticks(0xC000_0000);
+    let a = WrappingInstant::<u32, 1, 1_000>::from_ticks(0);
+    let b = WrappingInstant::<u32, 1, 1_000>::from_ticks(0x6000_0000);
+    let c = WrappingInstant::<u32, 1, 1_000>::from_ticks(0xC000_0000);
 
     assert!(a < b);
     assert!(b < c);
@@ -220,9 +294,9 @@ fn instant_compare_is_not_transitive_u32() {
 
 #[test]
 fn instant_compare_is_not_transitive_u64() {
-    let a = Instant::<u64, 1, 1_000>::from_ticks(0);
-    let b = Instant::<u64, 1, 1_000>::from_ticks(0x6000_0000_0000_0000);
-    let c = Instant::<u64, 1, 1_000>::from_ticks(0xC000_0000_0000_0000);
+    let a = WrappingInstant::<u64, 1, 1_000>::from_ticks(0);
+    let b = WrappingInstant::<u64, 1, 1_000>::from_ticks(0x6000_0000_0000_0000);
+    let c = WrappingInstant::<u64, 1, 1_000>::from_ticks(0xC000_0000_0000_0000);
 
     assert!(a < b);
     assert!(b < c);
@@ -236,23 +310,23 @@ fn instant_largest_fitting_conversion_constants_u32() {
     // conversion must still work: a ratio of exactly `u32::MAX` is the largest legal one.
     const MAX_RATIO: u64 = u32::MAX as u64;
 
-    let i = Instant::<u32, 1, 1>::from_ticks(1);
+    let i = WrappingInstant::<u32, 1, 1>::from_ticks(1);
     let d = Duration::<u32, 1, MAX_RATIO>::from_ticks(MAX_RATIO as u32);
 
     // MAX_RATIO ticks of 1/MAX_RATIO s is exactly one second.
     assert_eq!(
         i.convert_add_duration(d),
-        Some(Instant::<u32, 1, 1>::from_ticks(2))
+        Some(WrappingInstant::<u32, 1, 1>::from_ticks(2))
     );
     assert_eq!(
         i.convert_sub_duration(d),
-        Some(Instant::<u32, 1, 1>::from_ticks(0))
+        Some(WrappingInstant::<u32, 1, 1>::from_ticks(0))
     );
 
     // Sub-second remainders truncate toward zero rather than trapping.
     assert_eq!(
         i.convert_add_duration(Duration::<u32, 1, MAX_RATIO>::from_ticks(1)),
-        Some(Instant::<u32, 1, 1>::from_ticks(1))
+        Some(WrappingInstant::<u32, 1, 1>::from_ticks(1))
     );
 }
 
@@ -261,51 +335,53 @@ fn instant_duration_math_u32() {
     use crate::ExtU32;
 
     // Instant - Instant, Same base
-    let diff: Duration<u32, 1, 1_000> =
-        Instant::<u32, 1, 1_000>::from_ticks(10) - Instant::<u32, 1, 1_000>::from_ticks(1);
+    let diff: Duration<u32, 1, 1_000> = WrappingInstant::<u32, 1, 1_000>::from_ticks(10)
+        - WrappingInstant::<u32, 1, 1_000>::from_ticks(1);
     assert_eq!(diff, Duration::<u32, 1, 1_000>::from_ticks(9));
 
     // Instant +- Duration, Same base
-    let sum: Instant<u32, 1, 1_000> =
-        Instant::<u32, 1, 1_000>::from_ticks(10) + Duration::<u32, 1, 1_000>::from_ticks(1);
-    assert_eq!(sum, Instant::<u32, 1, 1_000>::from_ticks(11));
+    let sum: WrappingInstant<u32, 1, 1_000> =
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(10) + Duration::<u32, 1, 1_000>::from_ticks(1);
+    assert_eq!(sum, WrappingInstant::<u32, 1, 1_000>::from_ticks(11));
 
-    let mut sum = Instant::<u32, 1, 1_000>::from_ticks(10);
+    let mut sum = WrappingInstant::<u32, 1, 1_000>::from_ticks(10);
     sum += Duration::<u32, 1, 1_000>::from_ticks(1);
-    assert_eq!(sum, Instant::<u32, 1, 1_000>::from_ticks(11));
+    assert_eq!(sum, WrappingInstant::<u32, 1, 1_000>::from_ticks(11));
 
-    let diff: Instant<u32, 1, 1_000> =
-        Instant::<u32, 1, 1_000>::from_ticks(10) - Duration::<u32, 1, 1_000>::from_ticks(1);
-    assert_eq!(diff, Instant::<u32, 1, 1_000>::from_ticks(9));
+    let diff: WrappingInstant<u32, 1, 1_000> =
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(10) - Duration::<u32, 1, 1_000>::from_ticks(1);
+    assert_eq!(diff, WrappingInstant::<u32, 1, 1_000>::from_ticks(9));
 
-    let mut diff = Instant::<u32, 1, 1_000>::from_ticks(10);
+    let mut diff = WrappingInstant::<u32, 1, 1_000>::from_ticks(10);
     diff -= Duration::<u32, 1, 1_000>::from_ticks(1);
-    assert_eq!(diff, Instant::<u32, 1, 1_000>::from_ticks(9));
+    assert_eq!(diff, WrappingInstant::<u32, 1, 1_000>::from_ticks(9));
 
     // Instant +- Duration, Different base
-    let sum: Instant<u32, 1, 10_000> = Instant::<u32, 1, 10_000>::from_ticks(10)
+    let sum: WrappingInstant<u32, 1, 10_000> = WrappingInstant::<u32, 1, 10_000>::from_ticks(10)
         + Duration::<u32, 1, 1_000>::from_ticks(1).convert();
-    assert_eq!(sum, Instant::<u32, 1, 10_000>::from_ticks(20));
+    assert_eq!(sum, WrappingInstant::<u32, 1, 10_000>::from_ticks(20));
 
-    let mut sum = Instant::<u32, 1, 10_000>::from_ticks(10);
+    let mut sum = WrappingInstant::<u32, 1, 10_000>::from_ticks(10);
     sum += Duration::<u32, 1, 1_000>::from_ticks(1).convert();
-    assert_eq!(sum, Instant::<u32, 1, 10_000>::from_ticks(20));
+    assert_eq!(sum, WrappingInstant::<u32, 1, 10_000>::from_ticks(20));
 
-    let diff: Instant<u32, 1, 10_000> = Instant::<u32, 1, 10_000>::from_ticks(10)
+    let diff: WrappingInstant<u32, 1, 10_000> = WrappingInstant::<u32, 1, 10_000>::from_ticks(10)
         - Duration::<u32, 1, 1_000>::from_ticks(1).convert();
-    assert_eq!(diff, Instant::<u32, 1, 10_000>::from_ticks(0));
+    assert_eq!(diff, WrappingInstant::<u32, 1, 10_000>::from_ticks(0));
 
-    let mut diff = Instant::<u32, 1, 10_000>::from_ticks(10);
+    let mut diff = WrappingInstant::<u32, 1, 10_000>::from_ticks(10);
     diff -= Duration::<u32, 1, 1_000>::from_ticks(1).convert();
-    assert_eq!(diff, Instant::<u32, 1, 10_000>::from_ticks(0));
+    assert_eq!(diff, WrappingInstant::<u32, 1, 10_000>::from_ticks(0));
 
     // Instant + Extension trait
-    let sum: Instant<u32, 1, 10_000> = Instant::<u32, 1, 10_000>::from_ticks(10) + 1.millis();
-    assert_eq!(sum, Instant::<u32, 1, 10_000>::from_ticks(20));
+    let sum: WrappingInstant<u32, 1, 10_000> =
+        WrappingInstant::<u32, 1, 10_000>::from_ticks(10) + 1.millis();
+    assert_eq!(sum, WrappingInstant::<u32, 1, 10_000>::from_ticks(20));
 
     // Instant - Extension trait
-    let diff: Instant<u32, 1, 10_000> = Instant::<u32, 1, 10_000>::from_ticks(10) - 1.millis();
-    assert_eq!(diff, Instant::<u32, 1, 10_000>::from_ticks(0));
+    let diff: WrappingInstant<u32, 1, 10_000> =
+        WrappingInstant::<u32, 1, 10_000>::from_ticks(10) - 1.millis();
+    assert_eq!(diff, WrappingInstant::<u32, 1, 10_000>::from_ticks(0));
 }
 
 #[test]
@@ -313,86 +389,721 @@ fn instant_duration_math_u64() {
     use crate::ExtU64;
 
     // Instant - Instant, Same base
-    let diff: Duration<u64, 1, 1_000> =
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Instant::<u64, 1, 1_000>::from_ticks(1);
+    let diff: Duration<u64, 1, 1_000> = WrappingInstant::<u64, 1, 1_000>::from_ticks(10)
+        - WrappingInstant::<u64, 1, 1_000>::from_ticks(1);
     assert_eq!(diff, Duration::<u64, 1, 1_000>::from_ticks(9));
 
     // Instant +- Duration, Same base
-    let sum: Instant<u64, 1, 1_000> =
-        Instant::<u64, 1, 1_000>::from_ticks(10) + Duration::<u64, 1, 1_000>::from_ticks(1);
-    assert_eq!(sum, Instant::<u64, 1, 1_000>::from_ticks(11));
+    let sum: WrappingInstant<u64, 1, 1_000> =
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10) + Duration::<u64, 1, 1_000>::from_ticks(1);
+    assert_eq!(sum, WrappingInstant::<u64, 1, 1_000>::from_ticks(11));
 
-    let mut sum = Instant::<u64, 1, 1_000>::from_ticks(10);
+    let mut sum = WrappingInstant::<u64, 1, 1_000>::from_ticks(10);
     sum += Duration::<u64, 1, 1_000>::from_ticks(1);
-    assert_eq!(sum, Instant::<u64, 1, 1_000>::from_ticks(11));
+    assert_eq!(sum, WrappingInstant::<u64, 1, 1_000>::from_ticks(11));
 
-    let diff: Instant<u64, 1, 1_000> =
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Duration::<u64, 1, 1_000>::from_ticks(1);
-    assert_eq!(diff, Instant::<u64, 1, 1_000>::from_ticks(9));
+    let diff: WrappingInstant<u64, 1, 1_000> =
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10) - Duration::<u64, 1, 1_000>::from_ticks(1);
+    assert_eq!(diff, WrappingInstant::<u64, 1, 1_000>::from_ticks(9));
 
-    let mut diff = Instant::<u64, 1, 1_000>::from_ticks(10);
+    let mut diff = WrappingInstant::<u64, 1, 1_000>::from_ticks(10);
     diff -= Duration::<u64, 1, 1_000>::from_ticks(1);
-    assert_eq!(diff, Instant::<u64, 1, 1_000>::from_ticks(9));
+    assert_eq!(diff, WrappingInstant::<u64, 1, 1_000>::from_ticks(9));
 
     // Instant +- Duration, Different base
-    let sum: Instant<u64, 1, 10_000> = Instant::<u64, 1, 10_000>::from_ticks(10)
+    let sum: WrappingInstant<u64, 1, 10_000> = WrappingInstant::<u64, 1, 10_000>::from_ticks(10)
         + Duration::<u64, 1, 1_000>::from_ticks(1).convert();
-    assert_eq!(sum, Instant::<u64, 1, 10_000>::from_ticks(20));
+    assert_eq!(sum, WrappingInstant::<u64, 1, 10_000>::from_ticks(20));
 
-    let mut sum = Instant::<u64, 1, 10_000>::from_ticks(10);
+    let mut sum = WrappingInstant::<u64, 1, 10_000>::from_ticks(10);
     sum += Duration::<u64, 1, 1_000>::from_ticks(1).convert();
-    assert_eq!(sum, Instant::<u64, 1, 10_000>::from_ticks(20));
+    assert_eq!(sum, WrappingInstant::<u64, 1, 10_000>::from_ticks(20));
 
-    let diff: Instant<u64, 1, 10_000> = Instant::<u64, 1, 10_000>::from_ticks(10)
+    let diff: WrappingInstant<u64, 1, 10_000> = WrappingInstant::<u64, 1, 10_000>::from_ticks(10)
         - Duration::<u64, 1, 1_000>::from_ticks(1).convert();
-    assert_eq!(diff, Instant::<u64, 1, 10_000>::from_ticks(0));
+    assert_eq!(diff, WrappingInstant::<u64, 1, 10_000>::from_ticks(0));
 
-    let mut diff = Instant::<u64, 1, 10_000>::from_ticks(10);
+    let mut diff = WrappingInstant::<u64, 1, 10_000>::from_ticks(10);
     diff -= Duration::<u64, 1, 1_000>::from_ticks(1).convert();
-    assert_eq!(diff, Instant::<u64, 1, 10_000>::from_ticks(0));
+    assert_eq!(diff, WrappingInstant::<u64, 1, 10_000>::from_ticks(0));
 
     // Instant + Extension trait
-    let sum: Instant<u64, 1, 10_000> = Instant::<u64, 1, 10_000>::from_ticks(10) + 1.millis();
-    assert_eq!(sum, Instant::<u64, 1, 10_000>::from_ticks(20));
+    let sum: WrappingInstant<u64, 1, 10_000> =
+        WrappingInstant::<u64, 1, 10_000>::from_ticks(10) + 1.millis();
+    assert_eq!(sum, WrappingInstant::<u64, 1, 10_000>::from_ticks(20));
 
     // Instant - Extension trait
-    let diff: Instant<u64, 1, 10_000> = Instant::<u64, 1, 10_000>::from_ticks(10) - 1.millis();
-    assert_eq!(diff, Instant::<u64, 1, 10_000>::from_ticks(0));
+    let diff: WrappingInstant<u64, 1, 10_000> =
+        WrappingInstant::<u64, 1, 10_000>::from_ticks(10) - 1.millis();
+    assert_eq!(diff, WrappingInstant::<u64, 1, 10_000>::from_ticks(0));
 }
 
 #[test]
 fn instant_duration_math_u64_u32() {
     // Instant +- Duration, Same base
-    let sum: Instant<u64, 1, 1_000> =
-        Instant::<u64, 1, 1_000>::from_ticks(10) + Duration::<u32, 1, 1_000>::from_ticks(1);
-    assert_eq!(sum, Instant::<u64, 1, 1_000>::from_ticks(11));
+    let sum: WrappingInstant<u64, 1, 1_000> =
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10) + Duration::<u32, 1, 1_000>::from_ticks(1);
+    assert_eq!(sum, WrappingInstant::<u64, 1, 1_000>::from_ticks(11));
 
-    let mut sum = Instant::<u64, 1, 1_000>::from_ticks(10);
+    let mut sum = WrappingInstant::<u64, 1, 1_000>::from_ticks(10);
     sum += Duration::<u32, 1, 1_000>::from_ticks(1);
-    assert_eq!(sum, Instant::<u64, 1, 1_000>::from_ticks(11));
+    assert_eq!(sum, WrappingInstant::<u64, 1, 1_000>::from_ticks(11));
 
-    let diff: Instant<u64, 1, 1_000> =
-        Instant::<u64, 1, 1_000>::from_ticks(10) - Duration::<u32, 1, 1_000>::from_ticks(1);
-    assert_eq!(diff, Instant::<u64, 1, 1_000>::from_ticks(9));
+    let diff: WrappingInstant<u64, 1, 1_000> =
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(10) - Duration::<u32, 1, 1_000>::from_ticks(1);
+    assert_eq!(diff, WrappingInstant::<u64, 1, 1_000>::from_ticks(9));
 
-    let mut diff = Instant::<u64, 1, 1_000>::from_ticks(10);
+    let mut diff = WrappingInstant::<u64, 1, 1_000>::from_ticks(10);
     diff -= Duration::<u32, 1, 1_000>::from_ticks(1);
-    assert_eq!(diff, Instant::<u64, 1, 1_000>::from_ticks(9));
+    assert_eq!(diff, WrappingInstant::<u64, 1, 1_000>::from_ticks(9));
 
     // Instant +- Duration, Different base
-    let sum: Instant<u64, 1, 10_000> = Instant::<u64, 1, 10_000>::from_ticks(10)
+    let sum: WrappingInstant<u64, 1, 10_000> = WrappingInstant::<u64, 1, 10_000>::from_ticks(10)
         + Duration::<u32, 1, 1_000>::from_ticks(1).convert();
-    assert_eq!(sum, Instant::<u64, 1, 10_000>::from_ticks(20));
+    assert_eq!(sum, WrappingInstant::<u64, 1, 10_000>::from_ticks(20));
 
-    let mut sum = Instant::<u64, 1, 10_000>::from_ticks(10);
+    let mut sum = WrappingInstant::<u64, 1, 10_000>::from_ticks(10);
     sum += Duration::<u32, 1, 1_000>::from_ticks(1).convert();
-    assert_eq!(sum, Instant::<u64, 1, 10_000>::from_ticks(20));
+    assert_eq!(sum, WrappingInstant::<u64, 1, 10_000>::from_ticks(20));
 
-    let diff: Instant<u64, 1, 10_000> = Instant::<u64, 1, 10_000>::from_ticks(10)
+    let diff: WrappingInstant<u64, 1, 10_000> = WrappingInstant::<u64, 1, 10_000>::from_ticks(10)
         - Duration::<u32, 1, 1_000>::from_ticks(1).convert();
-    assert_eq!(diff, Instant::<u64, 1, 10_000>::from_ticks(0));
+    assert_eq!(diff, WrappingInstant::<u64, 1, 10_000>::from_ticks(0));
 
-    let mut diff = Instant::<u64, 1, 10_000>::from_ticks(10);
+    let mut diff = WrappingInstant::<u64, 1, 10_000>::from_ticks(10);
     diff -= Duration::<u32, 1, 1_000>::from_ticks(1).convert();
-    assert_eq!(diff, Instant::<u64, 1, 10_000>::from_ticks(0));
+    assert_eq!(diff, WrappingInstant::<u64, 1, 10_000>::from_ticks(0));
+}
+
+#[test]
+fn instant_operators_wrap_in_both_directions_u32() {
+    assert_eq!(
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(u32::MAX)
+            + Duration::<u32, 1, 1_000>::from_ticks(1),
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(0)
+    );
+    assert_eq!(
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(0) - Duration::<u32, 1, 1_000>::from_ticks(1),
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(u32::MAX)
+    );
+    assert_eq!(
+        WrappingInstant::<u32, 1, 1_000>::from_ticks(2)
+            - WrappingInstant::<u32, 1, 1_000>::from_ticks(u32::MAX),
+        Duration::<u32, 1, 1_000>::from_ticks(3)
+    );
+}
+
+#[test]
+fn instant_operators_wrap_in_both_directions_u64() {
+    assert_eq!(
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(u64::MAX)
+            + Duration::<u64, 1, 1_000>::from_ticks(1),
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(0)
+    );
+    assert_eq!(
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(0) - Duration::<u64, 1, 1_000>::from_ticks(1),
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(u64::MAX)
+    );
+    assert_eq!(
+        WrappingInstant::<u64, 1, 1_000>::from_ticks(2)
+            - WrappingInstant::<u64, 1, 1_000>::from_ticks(u64::MAX),
+        Duration::<u64, 1, 1_000>::from_ticks(3)
+    );
+}
+
+#[test]
+#[should_panic]
+fn instant_sub_incomparable_instant_panics_u32() {
+    const HALF: u32 = 1 << 31;
+
+    // Exactly half the range apart, so neither comes first and no duration exists.
+    let _ = WrappingInstant::<u32, 1, 1_000>::from_ticks(1)
+        - WrappingInstant::<u32, 1, 1_000>::from_ticks(1 + HALF);
+}
+
+#[test]
+#[should_panic]
+fn instant_sub_incomparable_instant_panics_u64() {
+    const HALF: u64 = 1 << 63;
+
+    let _ = WrappingInstant::<u64, 1, 1_000>::from_ticks(1)
+        - WrappingInstant::<u64, 1, 1_000>::from_ticks(1 + HALF);
+}
+
+#[test]
+fn instant_is_before_is_after_agree_with_operators_u32() {
+    const HALF: u32 = 1 << 31;
+
+    for (a, b) in [
+        (
+            WrappingInstant::<u32, 1, 1_000>::from_ticks(1),
+            WrappingInstant::<u32, 1, 1_000>::from_ticks(2),
+        ),
+        (
+            WrappingInstant::<u32, 1, 1_000>::from_ticks(2),
+            WrappingInstant::<u32, 1, 1_000>::from_ticks(1),
+        ),
+        (
+            WrappingInstant::<u32, 1, 1_000>::from_ticks(1),
+            WrappingInstant::<u32, 1, 1_000>::from_ticks(1),
+        ),
+        (
+            WrappingInstant::<u32, 1, 1_000>::from_ticks(u32::MAX),
+            WrappingInstant::<u32, 1, 1_000>::from_ticks(1),
+        ),
+        (
+            WrappingInstant::<u32, 1, 1_000>::from_ticks(1),
+            WrappingInstant::<u32, 1, 1_000>::from_ticks(u32::MAX),
+        ),
+        (
+            WrappingInstant::<u32, 1, 1_000>::from_ticks(u32::MAX - 1),
+            WrappingInstant::<u32, 1, 1_000>::from_ticks(u32::MAX),
+        ),
+    ] {
+        assert_eq!(a.is_before(b), a < b);
+        assert_eq!(a.is_after(b), a > b);
+    }
+
+    // Incomparable: neither predicate holds, matching `<` and `>`.
+    let a = WrappingInstant::<u32, 1, 1_000>::from_ticks(1);
+    let b = WrappingInstant::<u32, 1, 1_000>::from_ticks(1 + HALF);
+    assert!(!a.is_before(b) && !a.is_after(b));
+    assert!(!b.is_before(a) && !b.is_after(a));
+}
+
+#[test]
+fn instant_is_before_is_after_are_const_u32() {
+    // The reason these exist: `<` and `>` cannot be used in a const context.
+    const I1: WrappingInstant<u32, 1, 1_000> = WrappingInstant::<u32, 1, 1_000>::from_ticks(1);
+    const I2: WrappingInstant<u32, 1, 1_000> = WrappingInstant::<u32, 1, 1_000>::from_ticks(2);
+
+    const BEFORE: bool = I1.is_before(I2);
+    const AFTER: bool = I1.is_after(I2);
+
+    assert_eq!((BEFORE, AFTER), (true, false));
+}
+
+#[test]
+fn instant_is_before_is_after_are_const_u64() {
+    const I1: WrappingInstant<u64, 1, 1_000> = WrappingInstant::<u64, 1, 1_000>::from_ticks(1);
+    const I2: WrappingInstant<u64, 1, 1_000> = WrappingInstant::<u64, 1, 1_000>::from_ticks(2);
+
+    const BEFORE: bool = I1.is_before(I2);
+    const AFTER: bool = I1.is_after(I2);
+
+    assert_eq!((BEFORE, AFTER), (true, false));
+}
+
+#[test]
+fn instant_hash_follows_ticks_u32() {
+    use std::collections::hash_map::DefaultHasher;
+    use std::collections::HashMap;
+    use std::hash::{Hash, Hasher};
+
+    fn hash_of(i: WrappingInstant<u32, 1, 1_000>) -> u64 {
+        let mut h = DefaultHasher::new();
+        i.hash(&mut h);
+        h.finish()
+    }
+
+    assert_eq!(
+        hash_of(WrappingInstant::<u32, 1, 1_000>::from_ticks(7)),
+        hash_of(WrappingInstant::<u32, 1, 1_000>::from_ticks(7))
+    );
+    assert_ne!(
+        hash_of(WrappingInstant::<u32, 1, 1_000>::from_ticks(7)),
+        hash_of(WrappingInstant::<u32, 1, 1_000>::from_ticks(8))
+    );
+
+    let mut map = HashMap::new();
+    map.insert(WrappingInstant::<u32, 1, 1_000>::from_ticks(7), "seven");
+    assert_eq!(
+        map.get(&WrappingInstant::<u32, 1, 1_000>::from_ticks(7)),
+        Some(&"seven")
+    );
+    assert_eq!(
+        map.get(&WrappingInstant::<u32, 1, 1_000>::from_ticks(8)),
+        None
+    );
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Monotonic instants
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#[test]
+fn monotonic_instant_compare_u32() {
+    // Near MAX the comparison is a plain integer compare, the inverse of the wrapping kind.
+    assert!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(1)
+            < MonotonicInstant::<u32, 1, 1_000>::from_ticks(u32::MAX)
+    );
+    assert!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(u32::MAX - 1)
+            < MonotonicInstant::<u32, 1, 1_000>::from_ticks(u32::MAX)
+    );
+
+    assert!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(2)
+            > MonotonicInstant::<u32, 1, 1_000>::from_ticks(1)
+    );
+    assert!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(2)
+            >= MonotonicInstant::<u32, 1, 1_000>::from_ticks(1)
+    );
+    assert!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(1)
+            >= MonotonicInstant::<u32, 1, 1_000>::from_ticks(1)
+    );
+    assert!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(1)
+            < MonotonicInstant::<u32, 1, 1_000>::from_ticks(2)
+    );
+    assert!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(1)
+            <= MonotonicInstant::<u32, 1, 1_000>::from_ticks(1)
+    );
+    assert!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(1)
+            <= MonotonicInstant::<u32, 1, 1_000>::from_ticks(2)
+    );
+    assert!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(1)
+            == MonotonicInstant::<u32, 1, 1_000>::from_ticks(1)
+    );
+    assert!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(1)
+            != MonotonicInstant::<u32, 1, 1_000>::from_ticks(2)
+    );
+
+    assert_eq!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(1)
+            .checked_duration_since(MonotonicInstant::<u32, 1, 1_000>::from_ticks(1)),
+        Some(Duration::<u32, 1, 1_000>::from_ticks(0))
+    );
+    assert_eq!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(2)
+            .checked_duration_since(MonotonicInstant::<u32, 1, 1_000>::from_ticks(1)),
+        Some(Duration::<u32, 1, 1_000>::from_ticks(1))
+    );
+    assert_eq!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(2)
+            .checked_duration_since(MonotonicInstant::<u32, 1, 1_000>::from_ticks(3)),
+        None
+    );
+    assert_eq!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(u32::MAX)
+            .checked_duration_since(MonotonicInstant::<u32, 1, 1_000>::from_ticks(0)),
+        Some(Duration::<u32, 1, 1_000>::from_ticks(u32::MAX))
+    );
+    assert_eq!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(0)
+            .checked_duration_since(MonotonicInstant::<u32, 1, 1_000>::from_ticks(u32::MAX)),
+        None
+    );
+}
+
+#[test]
+fn monotonic_instant_compare_u64() {
+    assert!(
+        MonotonicInstant::<u64, 1, 1_000>::from_ticks(1)
+            < MonotonicInstant::<u64, 1, 1_000>::from_ticks(u64::MAX)
+    );
+    assert!(
+        MonotonicInstant::<u64, 1, 1_000>::from_ticks(u64::MAX - 1)
+            < MonotonicInstant::<u64, 1, 1_000>::from_ticks(u64::MAX)
+    );
+
+    assert!(
+        MonotonicInstant::<u64, 1, 1_000>::from_ticks(2)
+            > MonotonicInstant::<u64, 1, 1_000>::from_ticks(1)
+    );
+    assert!(
+        MonotonicInstant::<u64, 1, 1_000>::from_ticks(1)
+            == MonotonicInstant::<u64, 1, 1_000>::from_ticks(1)
+    );
+    assert!(
+        MonotonicInstant::<u64, 1, 1_000>::from_ticks(1)
+            != MonotonicInstant::<u64, 1, 1_000>::from_ticks(2)
+    );
+
+    assert_eq!(
+        MonotonicInstant::<u64, 1, 1_000>::from_ticks(2)
+            .checked_duration_since(MonotonicInstant::<u64, 1, 1_000>::from_ticks(1)),
+        Some(Duration::<u64, 1, 1_000>::from_ticks(1))
+    );
+    assert_eq!(
+        MonotonicInstant::<u64, 1, 1_000>::from_ticks(2)
+            .checked_duration_since(MonotonicInstant::<u64, 1, 1_000>::from_ticks(3)),
+        None
+    );
+    assert_eq!(
+        MonotonicInstant::<u64, 1, 1_000>::from_ticks(u64::MAX)
+            .checked_duration_since(MonotonicInstant::<u64, 1, 1_000>::from_ticks(0)),
+        Some(Duration::<u64, 1, 1_000>::from_ticks(u64::MAX))
+    );
+    assert_eq!(
+        MonotonicInstant::<u64, 1, 1_000>::from_ticks(0)
+            .checked_duration_since(MonotonicInstant::<u64, 1, 1_000>::from_ticks(u64::MAX)),
+        None
+    );
+}
+
+#[test]
+fn monotonic_instant_compare_is_transitive_u32() {
+    // The exact triple that `instant_compare_is_not_transitive_u32` uses to show why the
+    // wrapping kind cannot be `Ord`. Read monotonically, it is a plain total order.
+    let a = MonotonicInstant::<u32, 1, 1_000>::from_ticks(0);
+    let b = MonotonicInstant::<u32, 1, 1_000>::from_ticks(0x6000_0000);
+    let c = MonotonicInstant::<u32, 1, 1_000>::from_ticks(0xC000_0000);
+
+    assert!(a < b);
+    assert!(b < c);
+    assert!(a < c);
+}
+
+#[test]
+fn monotonic_instant_ord_works_with_std_collections_u32() {
+    use std::cmp::Reverse;
+    use std::collections::{BTreeSet, BinaryHeap};
+
+    fn assert_ord<T: Ord>() {}
+    assert_ord::<MonotonicInstant<u32, 1, 1_000>>();
+
+    let unsorted = [
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(u32::MAX),
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(3),
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(0),
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(7),
+    ];
+    let ascending = [
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(0),
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(3),
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(7),
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(u32::MAX),
+    ];
+
+    let mut sorted = unsorted;
+    sorted.sort();
+    assert_eq!(sorted, ascending);
+
+    assert_eq!(
+        unsorted.iter().max(),
+        Some(&MonotonicInstant::<u32, 1, 1_000>::from_ticks(u32::MAX))
+    );
+    assert_eq!(
+        unsorted.iter().min(),
+        Some(&MonotonicInstant::<u32, 1, 1_000>::from_ticks(0))
+    );
+
+    // Earliest-deadline-first, the use case that motivated keeping `Ord`.
+    let mut heap: BinaryHeap<Reverse<_>> = unsorted.iter().copied().map(Reverse).collect();
+    let mut popped = Vec::new();
+    while let Some(Reverse(next)) = heap.pop() {
+        popped.push(next);
+    }
+    assert_eq!(popped, ascending);
+
+    let set: BTreeSet<_> = unsorted.iter().copied().collect();
+    assert_eq!(set.into_iter().collect::<Vec<_>>(), ascending);
+}
+
+#[test]
+fn monotonic_instant_const_cmp_and_predicates_are_const_u32() {
+    use core::cmp::Ordering;
+
+    const I1: MonotonicInstant<u32, 1, 1_000> = MonotonicInstant::<u32, 1, 1_000>::from_ticks(1);
+    const I2: MonotonicInstant<u32, 1, 1_000> = MonotonicInstant::<u32, 1, 1_000>::from_ticks(2);
+
+    const CMP: Ordering = I1.const_cmp(I2);
+    const BEFORE: bool = I1.is_before(I2);
+    const AFTER: bool = I1.is_after(I2);
+
+    assert_eq!(CMP, Ordering::Less);
+    assert_eq!((BEFORE, AFTER), (true, false));
+}
+
+#[test]
+fn monotonic_instant_const_cmp_and_predicates_are_const_u64() {
+    use core::cmp::Ordering;
+
+    const I1: MonotonicInstant<u64, 1, 1_000> = MonotonicInstant::<u64, 1, 1_000>::from_ticks(2);
+    const I2: MonotonicInstant<u64, 1, 1_000> = MonotonicInstant::<u64, 1, 1_000>::from_ticks(1);
+
+    const CMP: Ordering = I1.const_cmp(I2);
+    const BEFORE: bool = I1.is_before(I2);
+    const AFTER: bool = I1.is_after(I2);
+
+    assert_eq!(CMP, Ordering::Greater);
+    assert_eq!((BEFORE, AFTER), (false, true));
+}
+
+#[test]
+fn monotonic_instant_predicates_agree_with_operators_u32() {
+    for (a, b) in [
+        (
+            MonotonicInstant::<u32, 1, 1_000>::from_ticks(1),
+            MonotonicInstant::<u32, 1, 1_000>::from_ticks(2),
+        ),
+        (
+            MonotonicInstant::<u32, 1, 1_000>::from_ticks(2),
+            MonotonicInstant::<u32, 1, 1_000>::from_ticks(1),
+        ),
+        (
+            MonotonicInstant::<u32, 1, 1_000>::from_ticks(1),
+            MonotonicInstant::<u32, 1, 1_000>::from_ticks(1),
+        ),
+        (
+            MonotonicInstant::<u32, 1, 1_000>::from_ticks(0),
+            MonotonicInstant::<u32, 1, 1_000>::from_ticks(u32::MAX),
+        ),
+        (
+            MonotonicInstant::<u32, 1, 1_000>::from_ticks(u32::MAX),
+            MonotonicInstant::<u32, 1, 1_000>::from_ticks(0),
+        ),
+        (
+            MonotonicInstant::<u32, 1, 1_000>::from_ticks(u32::MAX - 1),
+            MonotonicInstant::<u32, 1, 1_000>::from_ticks(u32::MAX),
+        ),
+    ] {
+        assert_eq!(a.is_before(b), a < b);
+        assert_eq!(a.is_after(b), a > b);
+    }
+}
+
+#[test]
+fn monotonic_instant_predicates_agree_with_operators_u64() {
+    for (a, b) in [
+        (
+            MonotonicInstant::<u64, 1, 1_000>::from_ticks(1),
+            MonotonicInstant::<u64, 1, 1_000>::from_ticks(2),
+        ),
+        (
+            MonotonicInstant::<u64, 1, 1_000>::from_ticks(2),
+            MonotonicInstant::<u64, 1, 1_000>::from_ticks(1),
+        ),
+        (
+            MonotonicInstant::<u64, 1, 1_000>::from_ticks(1),
+            MonotonicInstant::<u64, 1, 1_000>::from_ticks(1),
+        ),
+        (
+            MonotonicInstant::<u64, 1, 1_000>::from_ticks(0),
+            MonotonicInstant::<u64, 1, 1_000>::from_ticks(u64::MAX),
+        ),
+        (
+            MonotonicInstant::<u64, 1, 1_000>::from_ticks(u64::MAX),
+            MonotonicInstant::<u64, 1, 1_000>::from_ticks(0),
+        ),
+        (
+            MonotonicInstant::<u64, 1, 1_000>::from_ticks(u64::MAX - 1),
+            MonotonicInstant::<u64, 1, 1_000>::from_ticks(u64::MAX),
+        ),
+    ] {
+        assert_eq!(a.is_before(b), a < b);
+        assert_eq!(a.is_after(b), a > b);
+    }
+}
+
+#[test]
+fn monotonic_instant_checked_math_u32() {
+    let one_tick = Duration::<u32, 1, 1_000>::from_ticks(1);
+
+    assert_eq!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(10).checked_add_duration(one_tick),
+        Some(MonotonicInstant::<u32, 1, 1_000>::from_ticks(11))
+    );
+    assert_eq!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(10).checked_sub_duration(one_tick),
+        Some(MonotonicInstant::<u32, 1, 1_000>::from_ticks(9))
+    );
+
+    // Tick overflow in both directions, which is what distinguishes this from the wrapping kind.
+    assert_eq!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(u32::MAX).checked_add_duration(one_tick),
+        None
+    );
+    assert_eq!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(0).checked_sub_duration(one_tick),
+        None
+    );
+
+    // Base-conversion overflow, the other cause of `None`.
+    let too_big = Duration::<u32, 1, 500>::from_ticks(u32::MAX / 2 + 1);
+    assert_eq!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(1).checked_add_duration(too_big),
+        None
+    );
+    assert_eq!(
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(1).checked_sub_duration(too_big),
+        None
+    );
+
+    // Cross-base arithmetic that does fit.
+    assert_eq!(
+        MonotonicInstant::<u32, 1, 10_000>::from_ticks(10).checked_add_duration(one_tick),
+        Some(MonotonicInstant::<u32, 1, 10_000>::from_ticks(20))
+    );
+}
+
+#[test]
+fn monotonic_instant_checked_math_u64() {
+    let one_tick = Duration::<u64, 1, 1_000>::from_ticks(1);
+
+    assert_eq!(
+        MonotonicInstant::<u64, 1, 1_000>::from_ticks(10).checked_add_duration(one_tick),
+        Some(MonotonicInstant::<u64, 1, 1_000>::from_ticks(11))
+    );
+    assert_eq!(
+        MonotonicInstant::<u64, 1, 1_000>::from_ticks(10).checked_sub_duration(one_tick),
+        Some(MonotonicInstant::<u64, 1, 1_000>::from_ticks(9))
+    );
+    assert_eq!(
+        MonotonicInstant::<u64, 1, 1_000>::from_ticks(u64::MAX).checked_add_duration(one_tick),
+        None
+    );
+    assert_eq!(
+        MonotonicInstant::<u64, 1, 1_000>::from_ticks(0).checked_sub_duration(one_tick),
+        None
+    );
+}
+
+#[test]
+#[should_panic]
+fn monotonic_instant_sub_later_instant_panics_u32() {
+    // The explicit panic in `Sub<Instant>`, which fires in both profiles.
+    let _ = MonotonicInstant::<u32, 1, 1_000>::from_ticks(1)
+        - MonotonicInstant::<u32, 1, 1_000>::from_ticks(2);
+}
+
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic]
+fn monotonic_instant_add_overflow_panics_in_debug_u32() {
+    // Plain `+`, so this is an `overflow-checks` panic: debug only. The value side is covered
+    // by `checked_add_duration` returning `None`, which holds in both profiles.
+    let _ = MonotonicInstant::<u32, 1, 1_000>::from_ticks(u32::MAX)
+        + Duration::<u32, 1, 1_000>::from_ticks(1);
+}
+
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic]
+fn monotonic_instant_sub_underflow_panics_in_debug_u32() {
+    let _ =
+        MonotonicInstant::<u32, 1, 1_000>::from_ticks(0) - Duration::<u32, 1, 1_000>::from_ticks(1);
+}
+
+#[test]
+fn monotonic_instant_duration_math_u32() {
+    use crate::ExtU32;
+
+    let diff: Duration<u32, 1, 1_000> = MonotonicInstant::<u32, 1, 1_000>::from_ticks(10)
+        - MonotonicInstant::<u32, 1, 1_000>::from_ticks(1);
+    assert_eq!(diff, Duration::<u32, 1, 1_000>::from_ticks(9));
+
+    let sum: MonotonicInstant<u32, 1, 1_000> = MonotonicInstant::<u32, 1, 1_000>::from_ticks(10)
+        + Duration::<u32, 1, 1_000>::from_ticks(1);
+    assert_eq!(sum, MonotonicInstant::<u32, 1, 1_000>::from_ticks(11));
+
+    let mut sum = MonotonicInstant::<u32, 1, 1_000>::from_ticks(10);
+    sum += Duration::<u32, 1, 1_000>::from_ticks(1);
+    assert_eq!(sum, MonotonicInstant::<u32, 1, 1_000>::from_ticks(11));
+
+    let mut diff = MonotonicInstant::<u32, 1, 1_000>::from_ticks(10);
+    diff -= Duration::<u32, 1, 1_000>::from_ticks(1);
+    assert_eq!(diff, MonotonicInstant::<u32, 1, 1_000>::from_ticks(9));
+
+    // Extension traits, which need the same NOM/DENOM on both sides.
+    let sum: MonotonicInstant<u32, 1, 10_000> =
+        MonotonicInstant::<u32, 1, 10_000>::from_ticks(10) + 1.millis();
+    assert_eq!(sum, MonotonicInstant::<u32, 1, 10_000>::from_ticks(20));
+
+    let diff: MonotonicInstant<u32, 1, 10_000> =
+        MonotonicInstant::<u32, 1, 10_000>::from_ticks(10) - 1.millis();
+    assert_eq!(diff, MonotonicInstant::<u32, 1, 10_000>::from_ticks(0));
+}
+
+#[test]
+fn monotonic_instant_duration_math_u64_u32() {
+    // The cross-storage operators, which resolve through the kind's own same-base operator.
+    let sum: MonotonicInstant<u64, 1, 1_000> = MonotonicInstant::<u64, 1, 1_000>::from_ticks(10)
+        + Duration::<u32, 1, 1_000>::from_ticks(1);
+    assert_eq!(sum, MonotonicInstant::<u64, 1, 1_000>::from_ticks(11));
+
+    let mut sum = MonotonicInstant::<u64, 1, 1_000>::from_ticks(10);
+    sum += Duration::<u32, 1, 1_000>::from_ticks(1);
+    assert_eq!(sum, MonotonicInstant::<u64, 1, 1_000>::from_ticks(11));
+
+    let diff: MonotonicInstant<u64, 1, 1_000> = MonotonicInstant::<u64, 1, 1_000>::from_ticks(10)
+        - Duration::<u32, 1, 1_000>::from_ticks(1);
+    assert_eq!(diff, MonotonicInstant::<u64, 1, 1_000>::from_ticks(9));
+
+    let mut diff = MonotonicInstant::<u64, 1, 1_000>::from_ticks(10);
+    diff -= Duration::<u32, 1, 1_000>::from_ticks(1);
+    assert_eq!(diff, MonotonicInstant::<u64, 1, 1_000>::from_ticks(9));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Across the kinds
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#[test]
+fn debug_output_names_the_kind() {
+    assert_eq!(
+        format!("{:?}", WrappingInstant::<u32, 1, 1_000>::from_ticks(7)),
+        "WrappingInstant { ticks: 7 }"
+    );
+    assert_eq!(
+        format!("{:?}", MonotonicInstant::<u64, 1, 1_000>::from_ticks(7)),
+        "MonotonicInstant { ticks: 7 }"
+    );
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn both_kinds_implement_serde() {
+    fn assert_serde<T: serde::Serialize + serde::de::DeserializeOwned>() {}
+
+    assert_serde::<WrappingInstant<u32, 1, 1_000>>();
+    assert_serde::<MonotonicInstant<u64, 1, 1_000>>();
+}
+
+#[cfg(feature = "postcard_max_size")]
+#[test]
+fn both_kinds_implement_max_size() {
+    use postcard::experimental::max_size::MaxSize;
+
+    assert_eq!(
+        WrappingInstant::<u32, 1, 1_000>::POSTCARD_MAX_SIZE,
+        u32::POSTCARD_MAX_SIZE
+    );
+    assert_eq!(
+        MonotonicInstant::<u64, 1, 1_000>::POSTCARD_MAX_SIZE,
+        u64::POSTCARD_MAX_SIZE
+    );
+}
+
+#[test]
+fn both_kinds_hash_equal_ticks_equally_u64() {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    fn hash_of(value: impl Hash) -> u64 {
+        let mut h = DefaultHasher::new();
+        value.hash(&mut h);
+        h.finish()
+    }
+
+    assert_eq!(
+        hash_of(WrappingInstant::<u64, 1, 1_000>::from_ticks(7)),
+        hash_of(MonotonicInstant::<u64, 1, 1_000>::from_ticks(7))
+    );
+    assert_ne!(
+        hash_of(WrappingInstant::<u64, 1, 1_000>::from_ticks(7)),
+        hash_of(MonotonicInstant::<u64, 1, 1_000>::from_ticks(8))
+    );
 }


### PR DESCRIPTION
`Instant` gains a fourth type parameter naming its timeline:
- `Wrapping` keeps today's behaviour, ticks wrapping and a wrap-aware partial order.
- `Monotonic` is new which has total order and `Ord`.